### PR TITLE
Single sample alpha implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A public microservice to support The Microsetta Initiative
 ## Installation
 Create a new `conda` environment:
 
-`conda create -n microsetta-public-api python=3.7 flask
+`conda create -n microsetta-public-api python=3.7 flask`
 
 Once the conda environment is created, activate it:
 

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -1,16 +1,14 @@
 from flask import jsonify
 from microsetta_public_api.models._alpha import Alpha
-from microsetta_public_api.models._exceptions import UnknownID
 from microsetta_public_api.repo._alpha_repo import AlphaRepo
 
 
 def get_alpha(sample_id, alpha_metric):
     alpha_repo = AlphaRepo()
-    try:
-        alpha_series = alpha_repo.get_alpha_diversity([sample_id],
-                                                      alpha_metric)
-    except UnknownID:
+    if not all(alpha_repo.exists([sample_id])):
         return jsonify(error=404, text="Sample ID not found."), 404
+    alpha_series = alpha_repo.get_alpha_diversity([sample_id],
+                                                  alpha_metric)
     alpha_ = Alpha(alpha_series)
     alpha_data = alpha_.get_group_raw().to_dict()
     ret_val = {

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -7,10 +7,17 @@ from microsetta_public_api.repo._alpha_repo import AlphaRepo
 def get_alpha(sample_id, alpha_metric):
     alpha_repo = AlphaRepo()
     try:
-        alpha_series = alpha_repo.get_alpha_diversity(sample_id, alpha_metric)
+        alpha_series = alpha_repo.get_alpha_diversity([sample_id],
+                                                      alpha_metric)
     except UnknownID:
         return jsonify(error=404, text="Sample ID not found."), 404
     alpha_ = Alpha(alpha_series)
-    ret_val = alpha_.get_group_raw().to_dict()
+    alpha_data = alpha_.get_group_raw().to_dict()
+    ret_val = {
+        'sample_id': sample_id,
+        'alpha_metric': alpha_data['alpha_metric'],
+        'data': alpha_data['data'][sample_id],
+
+    }
 
     return jsonify(ret_val), 200

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -1,10 +1,13 @@
+import pandas as pd
 from flask import jsonify
+from microsetta_public_api.models._alpha import Alpha
 
 
 def get_alpha(sample_id, alpha_metric):
-    ret_val = {
-        'sample_id': sample_id,
-        'alpha_metric': alpha_metric,
-        'value': 8.25,
-    }
+    # TODO have some function grab this data from somewhere else
+    alpha_series = pd.Series({sample_id: 8.25}, name=alpha_metric)
+
+    alpha_ = Alpha(alpha_series)
+    ret_val = alpha_.get_group_raw().to_dict()
+
     return jsonify(ret_val), 200

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -1,12 +1,15 @@
-import pandas as pd
 from flask import jsonify
 from microsetta_public_api.models._alpha import Alpha
+from microsetta_public_api.models._exceptions import UnknownID
+from microsetta_public_api.repo._alpha_repo import AlphaRepo
 
 
 def get_alpha(sample_id, alpha_metric):
-    # TODO have some function grab this data from somewhere else
-    alpha_series = pd.Series({sample_id: 8.25}, name=alpha_metric)
-
+    alpha_repo = AlphaRepo()
+    try:
+        alpha_series = alpha_repo.get_alpha_diversity(sample_id, alpha_metric)
+    except UnknownID:
+        return jsonify(error=404, text="Sample ID not found."), 404
     alpha_ = Alpha(alpha_series)
     ret_val = alpha_.get_group_raw().to_dict()
 

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -29,7 +29,7 @@ paths:
                     $ref: '#/components/schemas/sample_id'
                   alpha_metric:
                     $ref: '#/components/schemas/alpha_metric'
-                  value:
+                  data:
                     type: number
                     example: 7.24
                     description: Alpha diversity value for sample ID with metric

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -53,6 +53,6 @@ class AlphaDiversityTests(FlaskTests):
             response = self.client.get(
                 '/api/diversity/alpha/observed_otus/sample-foo-bar')
 
-        self.assertRegexpMatches(response.data.decode(),
-                                 "Sample ID not found.")
+        self.assertRegex(response.data.decode(),
+                         "Sample ID not found.")
         self.assertEqual(response.status_code, 404)

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -53,6 +53,6 @@ class AlphaDiversityTests(FlaskTests):
             response = self.client.get(
                 '/api/diversity/alpha/observed_otus/sample-foo-bar')
 
-        self.assertRegexpMatches(response.data.decode(), "Sample ID not found.")
+        self.assertRegexpMatches(response.data.decode(),
+                                 "Sample ID not found.")
         self.assertEqual(response.status_code, 404)
-

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -1,8 +1,11 @@
 from unittest import TestCase
+from unittest.mock import patch
 import json
+import pandas as pd
 
 import microsetta_public_api
 import microsetta_public_api.server
+from microsetta_public_api.repo._alpha_repo import AlphaRepo
 
 
 class FlaskTests(TestCase):
@@ -21,11 +24,15 @@ class FlaskTests(TestCase):
 class AlphaDiversityTests(FlaskTests):
 
     def test_alpha_diversity_single_sample(self):
+        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method:
+            mock_method.return_value = pd.Series({
+                'sample-foo-bar': 8.25}, name='observed_otus')
 
-        response = self.client.get(
-            '/api/diversity/alpha/observed_otus/sample-foo-bar')
+            _, self.client = self.build_app_test_client()
 
-        # will need to be changed when alpha is fully implemented
+            response = self.client.get(
+                '/api/diversity/alpha/observed_otus/sample-foo-bar')
+
         exp = {
             'name': None,
             'alpha_metric': 'observed_otus',

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -27,9 +27,9 @@ class AlphaDiversityTests(FlaskTests):
 
         # will need to be changed when alpha is fully implemented
         exp = {
-            'sample_id': 'sample-foo-bar',
+            'name': None,
             'alpha_metric': 'observed_otus',
-            'value': 8.25,
+            'data': {'sample-foo-bar': 8.25},
         }
         obs = json.loads(response.data)
 

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -6,7 +6,6 @@ import pandas as pd
 import microsetta_public_api
 import microsetta_public_api.server
 from microsetta_public_api.repo._alpha_repo import AlphaRepo
-from microsetta_public_api.models._exceptions import UnknownID
 
 
 class FlaskTests(TestCase):
@@ -25,7 +24,9 @@ class FlaskTests(TestCase):
 class AlphaDiversityTests(FlaskTests):
 
     def test_alpha_diversity_single_sample(self):
-        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method:
+        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method,\
+                patch.object(AlphaRepo, 'exists') as mock_exists:
+            mock_exists.return_value = [True]
             mock_method.return_value = pd.Series({
                 'sample-foo-bar': 8.25}, name='observed_otus')
 
@@ -45,8 +46,8 @@ class AlphaDiversityTests(FlaskTests):
         self.assertEqual(response.status_code, 200)
 
     def test_alpha_diversity_unknown_id(self):
-        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method:
-            mock_method.side_effect = UnknownID
+        with patch.object(AlphaRepo, 'exists') as mock_exists:
+            mock_exists.return_value = [False]
 
             _, self.client = self.build_app_test_client()
 

--- a/microsetta_public_api/models/_alpha.py
+++ b/microsetta_public_api/models/_alpha.py
@@ -5,9 +5,9 @@ from microsetta_public_api.models._base import ModelBase
 from microsetta_public_api.models._exceptions import UnknownID
 from typing import Dict, List
 
-_gar_named = namedtuple('GroupAlphaRaw', ['name', 'metric', 'data'])
+_gar_named = namedtuple('GroupAlphaRaw', ['name', 'alpha_metric', 'data'])
 
-_ga_named = namedtuple('GroupAlpha', ['name', 'metric', 'mean', 'median',
+_ga_named = namedtuple('GroupAlpha', ['name', 'alpha_metric', 'mean', 'median',
                                       'std', 'group_size', 'percentile',
                                       'percentile_values'])
 
@@ -22,7 +22,7 @@ class GroupAlphaRaw(_gar_named):
     ----------
     name : str
         The name of the group.
-    metric : str
+    alpha_metric : str
         The name of the metric expressed.
     data : dict
         The sample to value data.
@@ -53,7 +53,7 @@ class GroupAlpha(_ga_named):
     ----------
     name : str
         The name of the group (e.g., 'sample-foo').
-    metric : str
+    alpha_metric : str
         The name of the metric expressed.
     mean : float
         The mean of the group values.
@@ -161,7 +161,7 @@ class Alpha(ModelBase):
             raise UnknownID('Identifier not found.')
 
         return GroupAlphaRaw(name=name,
-                             metric=self._series.name,
+                             alpha_metric=self._series.name,
                              data=vals.to_dict())
 
     def get_group(self, ids: List[str], name: str = None) -> GroupAlpha:
@@ -198,7 +198,7 @@ class Alpha(ModelBase):
         if len(ids) == 1:
             std = 0.
             return GroupAlpha(name=ids[0],
-                              metric=self._series.name,
+                              alpha_metric=self._series.name,
                               mean=mean,
                               median=median,
                               std=std,
@@ -212,7 +212,7 @@ class Alpha(ModelBase):
             std = vals.std(ddof=0)
             percentile_values = np.percentile(vals, self._percentiles)
             return GroupAlpha(name=name,
-                              metric=self._series.name,
+                              alpha_metric=self._series.name,
                               mean=mean,
                               median=median,
                               std=std,

--- a/microsetta_public_api/models/_base.py
+++ b/microsetta_public_api/models/_base.py
@@ -16,3 +16,6 @@ class ModelBase:
 
     def get_group_raw(self, ids=None, name=None):
         raise NotImplementedError
+
+    def to_api(self):
+        raise NotImplementedError

--- a/microsetta_public_api/models/tests/test_alpha.py
+++ b/microsetta_public_api/models/tests/test_alpha.py
@@ -30,7 +30,7 @@ class AlphaTests(unittest.TestCase):
     def test_get_group_single(self):
         adiv = Alpha(self.series)
         exp = GroupAlpha(name='b',
-                         metric='shannon',
+                         alpha_metric='shannon',
                          mean=0.2,
                          median=0.2,
                          std=0.0,
@@ -43,7 +43,7 @@ class AlphaTests(unittest.TestCase):
     def test_get_group_multi(self):
         adiv = Alpha(self.series)
         exp = GroupAlpha(name='bar',
-                         metric='shannon',
+                         alpha_metric='shannon',
                          mean=0.35,
                          median=0.35,
                          std=0.25,
@@ -53,7 +53,7 @@ class AlphaTests(unittest.TestCase):
                                             0.45, 0.5, 0.55])
         obs = adiv.get_group(['a', 'f'], 'bar')
         self.assertEqual(obs.name, exp.name)
-        self.assertEqual(obs.metric, exp.metric)
+        self.assertEqual(obs.alpha_metric, exp.alpha_metric)
         self.assertAlmostEqual(obs.mean, exp.mean)
         self.assertAlmostEqual(obs.median, exp.median)
         self.assertAlmostEqual(obs.std, exp.std)
@@ -77,14 +77,14 @@ class AlphaTests(unittest.TestCase):
                                 index=['a', 'b', 'c', 'd', 'e', 'f'],
                                 name='shannon')
         exp_all = GroupAlphaRaw(name=None,
-                                metric='shannon',
+                                alpha_metric='shannon',
                                 data={'a': 0.1, 'b': 0.2, 'c': 0.8, 'd': 0.7,
                                       'e': 0.7, 'f': 0.6})
         obs_all = adiv.get_group_raw()
         self.assertEqual(obs_all, exp_all)
 
         exp_partial = GroupAlphaRaw(name='foo',
-                                    metric='shannon',
+                                    alpha_metric='shannon',
                                     data={'a': 0.1, 'c': 0.8, 'f': 0.6})
         obs_partial = adiv.get_group_raw(['a', 'c', 'f'], 'foo')
         self.assertEqual(obs_partial, exp_partial)
@@ -103,15 +103,15 @@ class AlphaTests(unittest.TestCase):
 class GroupAlphaRawTests(unittest.TestCase):
     def setUp(self):
         self.obj = GroupAlphaRaw(name=None,
-                                 metric='shannon',
+                                 alpha_metric='shannon',
                                  data={'a': 10, 'b': 20})
         self.obj2 = GroupAlphaRaw(name='foobar',
-                                  metric='shannon',
+                                  alpha_metric='shannon',
                                   data={'a': 10, 'b': 20, 'c': 30})
 
     def test_init(self):
         self.assertEqual(self.obj.name, None)
-        self.assertEqual(self.obj.metric, 'shannon')
+        self.assertEqual(self.obj.alpha_metric, 'shannon')
         self.assertEqual(self.obj.data, {'a': 10, 'b': 20})
 
     def test_init_nokw(self):
@@ -122,7 +122,7 @@ class GroupAlphaRawTests(unittest.TestCase):
 class GroupAlphaTests(unittest.TestCase):
     def setUp(self):
         self.obj = GroupAlpha(name='sample-1',
-                              metric='shannon',
+                              alpha_metric='shannon',
                               mean=0.2,
                               median=0.2,
                               std=0.0,
@@ -131,7 +131,7 @@ class GroupAlphaTests(unittest.TestCase):
                               percentile_values=None)
 
         self.obj2 = GroupAlpha(name='abx-low',
-                               metric='faiths',
+                               alpha_metric='faiths',
                                mean=0.5,
                                median=0.4,
                                std=0.1,
@@ -141,7 +141,7 @@ class GroupAlphaTests(unittest.TestCase):
 
     def test_init(self):
         self.assertEqual(self.obj.name, 'sample-1')
-        self.assertEqual(self.obj.metric, 'shannon')
+        self.assertEqual(self.obj.alpha_metric, 'shannon')
         self.assertEqual(self.obj.mean, 0.2)
         self.assertEqual(self.obj.median, 0.2)
         self.assertEqual(self.obj.std, 0.0)
@@ -152,7 +152,7 @@ class GroupAlphaTests(unittest.TestCase):
     def test_init_group_size_lte_0(self):
         with self.assertRaisesRegex(ValueError, "bad group_size."):
             GroupAlpha(name='abx-low',
-                       metric='faiths',
+                       alpha_metric='faiths',
                        mean=0.5,
                        median=0.4,
                        std=0.1,
@@ -163,7 +163,7 @@ class GroupAlphaTests(unittest.TestCase):
     def test_init_group_size_gt_1(self):
         with self.assertRaisesRegex(ValueError, "unmatched percentiles."):
             GroupAlpha(name='abx-low',
-                       metric='faiths',
+                       alpha_metric='faiths',
                        mean=0.5,
                        median=0.4,
                        std=0.1,
@@ -173,7 +173,7 @@ class GroupAlphaTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "unmatched percentiles."):
             GroupAlpha(name='abx-low',
-                       metric='faiths',
+                       alpha_metric='faiths',
                        mean=0.5,
                        median=0.4,
                        std=0.1,
@@ -183,7 +183,7 @@ class GroupAlphaTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Missing percentiles."):
             GroupAlpha(name='abx-low',
-                       metric='faiths',
+                       alpha_metric='faiths',
                        mean=0.5,
                        median=0.4,
                        std=0.1,
@@ -193,7 +193,7 @@ class GroupAlphaTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Missing percentiles."):
             GroupAlpha(name='abx-low',
-                       metric='faiths',
+                       alpha_metric='faiths',
                        mean=0.5,
                        median=0.4,
                        std=0.1,
@@ -203,7 +203,7 @@ class GroupAlphaTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Missing percentiles."):
             GroupAlpha(name='abx-low',
-                       metric='faiths',
+                       alpha_metric='faiths',
                        mean=0.5,
                        median=0.4,
                        std=0.1,
@@ -214,7 +214,7 @@ class GroupAlphaTests(unittest.TestCase):
     def test_init_group_size_1(self):
         with self.assertRaisesRegex(ValueError, "non-sensical for n=1."):
             GroupAlpha(name='sample-1',
-                       metric='faiths',
+                       alpha_metric='faiths',
                        mean=0.4,
                        median=0.5,
                        std=0.0,
@@ -224,7 +224,7 @@ class GroupAlphaTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "non-sensical for n=1."):
             GroupAlpha(name='sample-1',
-                       metric='faiths',
+                       alpha_metric='faiths',
                        mean=0.5,
                        median=0.4,
                        std=0.0,
@@ -234,7 +234,7 @@ class GroupAlphaTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "non-sensical for n=1."):
             GroupAlpha(name='sample-1',
-                       metric='faiths',
+                       alpha_metric='faiths',
                        mean=0.4,
                        median=0.4,
                        std=0.0,
@@ -244,7 +244,7 @@ class GroupAlphaTests(unittest.TestCase):
 
     def test_to_dict(self):
         exp = {'name': 'abx-low',
-               'metric': 'faiths',
+               'alpha_metric': 'faiths',
                'mean': 0.5,
                'median': 0.4,
                'std': 0.1,
@@ -255,7 +255,7 @@ class GroupAlphaTests(unittest.TestCase):
         self.assertEqual(obs, exp)
 
         exp = {'name': 'sample-1',
-               'metric': 'shannon',
+               'alpha_metric': 'shannon',
                'mean': 0.2,
                'median': 0.2,
                'std': 0.0,

--- a/microsetta_public_api/repo/_alpha_repo.py
+++ b/microsetta_public_api/repo/_alpha_repo.py
@@ -1,0 +1,27 @@
+class AlphaRepo:
+
+    def get_alpha_diversity(self, sample_ids, metric):
+        """
+
+        Parameters
+        ----------
+        sample_ids : list of str
+            Ids for which to obtain alpha diversity measure.
+
+        metric : str
+            Alpha diversity metric.
+
+        Returns
+        -------
+        pd.Series
+            Contains alpha diversity with metric `metric` for the samples in
+            sample_ids with name=`metric`.
+
+        Raises
+        ------
+        microsetta_public_api.models._exceptions.UknownID
+            If an id in sample_ids does not exist in the database.
+
+        """
+
+        raise NotImplementedError

--- a/microsetta_public_api/repo/_alpha_repo.py
+++ b/microsetta_public_api/repo/_alpha_repo.py
@@ -1,7 +1,7 @@
 class AlphaRepo:
 
     def get_alpha_diversity(self, sample_ids, metric):
-        """
+        """Obtains alpha diversity of a given metric for a list of samples.
 
         Parameters
         ----------

--- a/microsetta_public_api/repo/_alpha_repo.py
+++ b/microsetta_public_api/repo/_alpha_repo.py
@@ -14,13 +14,27 @@ class AlphaRepo:
         Returns
         -------
         pd.Series
-            Contains alpha diversity with metric `metric` for the samples in
-            sample_ids with name=`metric`.
+            Contains alpha diversity with metric `metric` for the
+            union of samples ids in the database the ids in `sample_ids`.
+            Sets the name of the series to `metric`.
 
-        Raises
-        ------
-        microsetta_public_api.models._exceptions.UknownID
-            If an id in sample_ids does not exist in the database.
+        """
+
+        raise NotImplementedError
+
+    def exists(self, sample_ids):
+        """Checks if sample_ids exists in the database.
+
+        Parameters
+        ----------
+        sample_ids : list of str
+            Ids for to check database for.
+
+        Returns
+        -------
+        list of bool
+            each entry `i` corresponds to whether `sample_ids[i]` exists
+            in the database.
 
         """
 


### PR DESCRIPTION
Summary of changes:

* `README.md`
    * small fix
* `microsetta_public_api/api/diversity/alpha.py`
    * Replaced placeholder function with a function that matches the OpenAPI spec better
* `microsetta_public_api/repo/_alpha_repo.py`
    * Added. In the future, this should be the place where alpha diversity is obtained from the backend.
* `microsetta_public_api/models/_alpha.py`
    * change `metric` to `alpha_metric` to better reflect API spec
* `microsetta_public_api/api/microsetta_public_api.yml`
    * change `value` to `data` to better be forward compatible with array of alpha diversity (next milestone)
* `microsetta_public_api/api/tests/test_api.py`
    * Mock the return value from `AlphaRepo`
    * Reflect `value` to `data` change
    * Assert that we get a 404 error if there is an UnkownID