### PR TITLE
First draft of group alpha retrieval

### DIFF
--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -21,7 +21,7 @@ def get_alpha(sample_id, alpha_metric):
     return jsonify(ret_val), 200
 
 
-def alpha_group(body, alpha_metric, name=None):
+def alpha_group(body, alpha_metric):
     sample_ids = body['sample_ids']
 
     alpha_repo = AlphaRepo()
@@ -31,7 +31,7 @@ def alpha_group(body, alpha_metric, name=None):
                                                   alpha_metric,
                                                   )
     alpha_ = Alpha(alpha_series)
-    alpha_data = alpha_.get_group_raw(name=name).to_dict()
+    alpha_data = alpha_.get_group_raw().to_dict()
 
     if alpha_data['name'] is None:
         del alpha_data['name']

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -14,8 +14,28 @@ def get_alpha(sample_id, alpha_metric):
     ret_val = {
         'sample_id': sample_id,
         'alpha_metric': alpha_data['alpha_metric'],
-        'data': alpha_data['data'][sample_id],
+        'data': alpha_data['alpha_diversity'][sample_id],
 
     }
 
     return jsonify(ret_val), 200
+
+
+def alpha_group(body, alpha_metric, name=None):
+    sample_ids = body['sample_ids']
+
+    alpha_repo = AlphaRepo()
+    if not all(alpha_repo.exists([sample_ids])):
+        return jsonify(error=404, text="Sample ID not found."), 404
+    alpha_series = alpha_repo.get_alpha_diversity([sample_ids],
+                                                  alpha_metric,
+                                                  )
+    alpha_ = Alpha(alpha_series)
+    alpha_data = alpha_.get_group_raw(name=name).to_dict()
+
+    if alpha_data['name'] is None:
+        del alpha_data['name']
+
+    response = jsonify(alpha_data)
+    response.status_code = 200
+    return response

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -26,10 +26,10 @@ def alpha_group(body, alpha_metric):
     sample_ids = body['sample_ids']
 
     alpha_repo = AlphaRepo()
-    exists = zip(sample_ids, alpha_repo.exists(sample_ids))
-    missing_filter = filter(lambda x: not x[1], exists)
-    missing_ids = [item[0] for item in missing_filter]
-    if not all(alpha_repo.exists(sample_ids)):
+    missing_ids = [id_ for id_, exists in
+                   zip(sample_ids, alpha_repo.exists(sample_ids))
+                   if not exists]
+    if len(missing_ids) > 0:
         return jsonify(missing_ids=missing_ids,
                        error=404, text="Sample ID(s) not found."),\
                        404

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -6,7 +6,8 @@ from microsetta_public_api.repo._alpha_repo import AlphaRepo
 def get_alpha(sample_id, alpha_metric):
     alpha_repo = AlphaRepo()
     if not all(alpha_repo.exists([sample_id])):
-        return jsonify(error=404, text="Sample ID not found."), 404
+        return jsonify(error=404, text="Sample ID not found."),\
+               404
     alpha_series = alpha_repo.get_alpha_diversity([sample_id],
                                                   alpha_metric)
     alpha_ = Alpha(alpha_series)
@@ -25,9 +26,14 @@ def alpha_group(body, alpha_metric):
     sample_ids = body['sample_ids']
 
     alpha_repo = AlphaRepo()
-    if not all(alpha_repo.exists([sample_ids])):
-        return jsonify(error=404, text="Sample ID not found."), 404
-    alpha_series = alpha_repo.get_alpha_diversity([sample_ids],
+    exists = zip(sample_ids, alpha_repo.exists(sample_ids))
+    missing_filter = filter(lambda x: not x[1], exists)
+    missing_ids = [item[0] for item in missing_filter]
+    if not all(alpha_repo.exists(sample_ids)):
+        return jsonify(missing_ids=missing_ids,
+                       error=404, text="Sample ID(s) not found."),\
+                       404
+    alpha_series = alpha_repo.get_alpha_diversity(sample_ids,
                                                   alpha_metric,
                                                   )
     alpha_ = Alpha(alpha_series)

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -26,9 +26,7 @@ def alpha_group(body, alpha_metric):
     sample_ids = body['sample_ids']
 
     alpha_repo = AlphaRepo()
-    missing_ids = [id_ for id_, exists in
-                   zip(sample_ids, alpha_repo.exists(sample_ids))
-                   if not exists]
+    missing_ids = [id_ for id_ in sample_ids if not alpha_repo.exists(id_)]
     if len(missing_ids) > 0:
         return jsonify(missing_ids=missing_ids,
                        error=404, text="Sample ID(s) not found."),\

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -36,6 +36,64 @@ paths:
         '404':
           $ref: '#/components/responses/404SampleNotFound'
 
+  '/diversity/alpha_group/{alpha_metric}':
+    post:
+      operationId: microsetta_public_api.api.diversity.alpha.alpha_group
+      tags:
+        - Diversity
+      summary: Query alpha diversity for a group of samples
+      description: Query alpha diversity for a group of samples
+
+      parameters:
+        - $ref: '#/components/parameters/alpha_metric'
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - sample_ids
+              properties:
+                sample_ids:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/sample_id'
+                  example:
+                    - "sample1"
+                    - "sample2"
+                    - "sample3"
+
+      responses:
+        '200':
+          description: Successfuly return alpha diversity information
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - alpha_metric
+                  - alpha_diversity
+                properties:
+                  alpha_metric:
+                    $ref: '#/components/schemas/alpha_metric'
+                  name:
+                    type: string
+                  alpha_diversity:
+                    type: object
+                    additionalProperties:
+                      type: number
+                      example: 7.24
+                      description: Alpha diversity value for sample ID with metric
+                    example:
+                      {
+                        "sample1": 0.1,
+                        "sample2": 9.01,
+                        "sample3": 7.24,
+                      }
+        '404':
+          $ref: '#/components/responses/404SampleNotFound'
+
 components:
   parameters:
     alpha_metric:
@@ -60,7 +118,6 @@ components:
       example: "faith_pd"
     sample_id:
       type: string
-      readOnly: true # sent in GET, not in POST/PUT/PATC
       example: "dae21127-27bb-4f52-9fd3-a2aa5eb5b86f"
 
   responses:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -77,8 +77,6 @@ paths:
                 properties:
                   alpha_metric:
                     $ref: '#/components/schemas/alpha_metric'
-                  name:
-                    type: string
                   alpha_diversity:
                     type: object
                     additionalProperties:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -121,3 +121,16 @@ components:
   responses:
     404SampleNotFound:       # Can be referenced as '#/components/responses/404NotFound'
       description: The specified sample was not found.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              missing_ids:
+                type: array
+                description: Missing IDs.
+                items:
+                  $ref: '#/components/schemas/sample_id'
+                  example:
+                    - "sample1"
+                    - "sample2"

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -106,5 +106,5 @@ class AlphaDiversityTests(FlaskTests):
         self.assertListEqual(api_out['missing_ids'],
                              ['sample-baz-bat'])
         self.assertRegex(api_out['text'],
-                         'Sample ID\(s\) not found.')
+                         r'Sample ID\(s\) not found.')
         self.assertEqual(response.status_code, 404)

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -102,7 +102,9 @@ class AlphaDiversityTests(FlaskTests):
                                                 'sample-baz-bat']
                                  })
             )
-
-        self.assertRegex(response.data.decode(),
-                         "Sample ID not found.")
+        api_out = json.loads(response.data.decode())
+        self.assertListEqual(api_out['missing_ids'],
+                             ['sample-baz-bat'])
+        self.assertRegex(api_out['text'],
+                         'Sample ID\(s\) not found.')
         self.assertEqual(response.status_code, 404)

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -57,3 +57,52 @@ class AlphaDiversityTests(FlaskTests):
         self.assertRegex(response.data.decode(),
                          "Sample ID not found.")
         self.assertEqual(response.status_code, 404)
+
+    def test_alpha_diversity_group(self):
+        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method, \
+                patch.object(AlphaRepo, 'exists') as mock_exists:
+            mock_exists.return_value = [True, True]
+            mock_method.return_value = pd.Series({
+                'sample-foo-bar': 8.25, 'sample-baz-bat': 9.01},
+                name='observed_otus'
+                )
+
+            _, self.client = self.build_app_test_client()
+
+            response = self.client.post(
+                '/api/diversity/alpha_group/observed_otus',
+                content_type='application/json',
+                data=json.dumps({'sample_ids': ['sample-foo-bar',
+                                                'sample-baz-bat']
+                                 })
+            )
+
+        exp = {
+            'alpha_metric': 'observed_otus',
+            'alpha_diversity': {'sample-foo-bar': 8.25,
+                                'sample-baz-bat': 9.01,
+                                }
+        }
+        obs = json.loads(response.data)
+
+        self.assertDictEqual(exp, obs)
+        self.assertEqual(response.status_code, 200)
+
+    def test_alpha_diversity_group_unknown_sample(self):
+        with patch.object(AlphaRepo, 'exists') as mock_exists:
+            mock_exists.return_value = [True, False]
+
+            _, self.client = self.build_app_test_client()
+
+            response = self.client.post(
+                '/api/diversity/alpha_group/observed_otus',
+                content_type='application/json',
+                data=json.dumps({'metric': 'observed_otus',
+                                 'sample_ids': ['sample-foo-bar',
+                                                'sample-baz-bat']
+                                 })
+            )
+
+        self.assertRegex(response.data.decode(),
+                         "Sample ID not found.")
+        self.assertEqual(response.status_code, 404)

--- a/microsetta_public_api/models/_alpha.py
+++ b/microsetta_public_api/models/_alpha.py
@@ -5,7 +5,8 @@ from microsetta_public_api.models._base import ModelBase
 from microsetta_public_api.models._exceptions import UnknownID
 from typing import Dict, List
 
-_gar_named = namedtuple('GroupAlphaRaw', ['name', 'alpha_metric', 'data'])
+_gar_named = namedtuple('GroupAlphaRaw', ['name', 'alpha_metric',
+                                          'alpha_diversity'])
 
 _ga_named = namedtuple('GroupAlpha', ['name', 'alpha_metric', 'mean', 'median',
                                       'std', 'group_size', 'percentile',
@@ -24,7 +25,7 @@ class GroupAlphaRaw(_gar_named):
         The name of the group.
     alpha_metric : str
         The name of the metric expressed.
-    data : dict
+    alpha_diversity : dict
         The sample to value data.
     """
     __slots__ = ()
@@ -162,7 +163,7 @@ class Alpha(ModelBase):
 
         return GroupAlphaRaw(name=name,
                              alpha_metric=self._series.name,
-                             data=vals.to_dict())
+                             alpha_diversity=vals.to_dict())
 
     def get_group(self, ids: List[str], name: str = None) -> GroupAlpha:
         """Get group values

--- a/microsetta_public_api/models/tests/test_alpha.py
+++ b/microsetta_public_api/models/tests/test_alpha.py
@@ -78,14 +78,15 @@ class AlphaTests(unittest.TestCase):
                                 name='shannon')
         exp_all = GroupAlphaRaw(name=None,
                                 alpha_metric='shannon',
-                                data={'a': 0.1, 'b': 0.2, 'c': 0.8, 'd': 0.7,
-                                      'e': 0.7, 'f': 0.6})
+                                alpha_diversity={'a': 0.1, 'b': 0.2, 'c': 0.8,
+                                                 'd': 0.7, 'e': 0.7, 'f': 0.6})
         obs_all = adiv.get_group_raw()
         self.assertEqual(obs_all, exp_all)
 
         exp_partial = GroupAlphaRaw(name='foo',
                                     alpha_metric='shannon',
-                                    data={'a': 0.1, 'c': 0.8, 'f': 0.6})
+                                    alpha_diversity={'a': 0.1, 'c': 0.8,
+                                                     'f': 0.6})
         obs_partial = adiv.get_group_raw(['a', 'c', 'f'], 'foo')
         self.assertEqual(obs_partial, exp_partial)
 
@@ -104,15 +105,15 @@ class GroupAlphaRawTests(unittest.TestCase):
     def setUp(self):
         self.obj = GroupAlphaRaw(name=None,
                                  alpha_metric='shannon',
-                                 data={'a': 10, 'b': 20})
+                                 alpha_diversity={'a': 10, 'b': 20})
         self.obj2 = GroupAlphaRaw(name='foobar',
                                   alpha_metric='shannon',
-                                  data={'a': 10, 'b': 20, 'c': 30})
+                                  alpha_diversity={'a': 10, 'b': 20, 'c': 30})
 
     def test_init(self):
         self.assertEqual(self.obj.name, None)
         self.assertEqual(self.obj.alpha_metric, 'shannon')
-        self.assertEqual(self.obj.data, {'a': 10, 'b': 20})
+        self.assertEqual(self.obj.alpha_diversity, {'a': 10, 'b': 20})
 
     def test_init_nokw(self):
         with self.assertRaises(NotImplementedError):

--- a/microsetta_public_api/repo/_alpha_repo.py
+++ b/microsetta_public_api/repo/_alpha_repo.py
@@ -27,13 +27,15 @@ class AlphaRepo:
 
         Parameters
         ----------
-        sample_ids : list of str
+        sample_ids : str or list of str
             Ids for to check database for.
 
         Returns
         -------
-        list of bool
-            each entry `i` corresponds to whether `sample_ids[i]` exists
+        bool or list of bool
+            If sample_ids is str, then this returns a bool corresponding to
+            whether the given sample ID exists. If given a list, each entry
+            `i` corresponds to whether `sample_ids[i]` exists
             in the database.
 
         """


### PR DESCRIPTION
Summary of major changes:

* Added a `POST` for `/diversity/alpha_group/{alpha_metric}` that should allow you to post a JSON that will allow you to request the alpha diversity for samples that you specify
* Added `microsetta_public_api.diversity.alpha_group` which parses the request and prepares a response for the above POST.
* changed a field `diversity` to `alpha_diversity` to be more explicit.