### PR TITLE
Expose alpha summary statistics

### DIFF
--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -25,7 +25,8 @@ def get_alpha(sample_id, alpha_metric):
     return jsonify(ret_val), 200
 
 
-def alpha_group(body, alpha_metric, summary_statistics, percentiles):
+def alpha_group(body, alpha_metric, summary_statistics=False,
+                percentiles=None):
     sample_ids = body['sample_ids']
 
     alpha_repo = AlphaRepo()
@@ -58,8 +59,7 @@ def alpha_group(body, alpha_metric, summary_statistics, percentiles):
         del alpha_data['name']
 
     response = jsonify(alpha_data)
-    response.status_code = 200
-    return response
+    return response, 200
 
 
 def available_metrics_alpha():

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -25,7 +25,7 @@ def get_alpha(sample_id, alpha_metric):
     return jsonify(ret_val), 200
 
 
-def alpha_group(body, alpha_metric):
+def alpha_group(body, alpha_metric, summary_statistics, percentiles):
     sample_ids = body['sample_ids']
 
     alpha_repo = AlphaRepo()

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -60,11 +60,20 @@ def alpha_group(body, alpha_metric, summary_statistics=True,
     alpha_series = alpha_repo.get_alpha_diversity(sample_ids,
                                                   alpha_metric,
                                                   )
-    alpha_ = Alpha(alpha_series)
-    alpha_data = alpha_.get_group_raw().to_dict()
+    alpha_ = Alpha(alpha_series, percentiles=percentiles)
+    alpha_data = dict()
 
-    if alpha_data['name'] is None:
-        del alpha_data['name']
+    if return_raw:
+        # not using name right now, so give it a placeholder name
+        alpha_values = alpha_.get_group_raw(name='').to_dict()
+        del alpha_values['name']
+        alpha_data.update(alpha_values)
+    if summary_statistics:
+        # not using name right now, so give it a placeholder name
+        alpha_summary = alpha_.get_group(name='').to_dict()
+        del alpha_summary['name']
+        alpha_data.update({'alpha_metric': alpha_summary.pop('alpha_metric')})
+        alpha_data.update({'group_summary': alpha_summary})
 
     response = jsonify(alpha_data)
     return response, 200

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -25,8 +25,8 @@ def get_alpha(sample_id, alpha_metric):
     return jsonify(ret_val), 200
 
 
-def alpha_group(body, alpha_metric, summary_statistics=False,
-                percentiles=None):
+def alpha_group(body, alpha_metric, summary_statistics=True,
+                percentiles=None, return_raw=False):
     sample_ids = body['sample_ids']
 
     alpha_repo = AlphaRepo()

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -27,6 +27,14 @@ def get_alpha(sample_id, alpha_metric):
 
 def alpha_group(body, alpha_metric, summary_statistics=True,
                 percentiles=None, return_raw=False):
+    if not (summary_statistics or return_raw):
+        # swagger does not account for parameter dependencies, so we should
+        #  give a bad request error here
+        return jsonify(
+            error=400, text='Either `summary_statistics`, `return_raw`, '
+                            'or both are required to be true.'
+            ), 400
+
     sample_ids = body['sample_ids']
 
     alpha_repo = AlphaRepo()

--- a/microsetta_public_api/api/diversity/tests/test_alpha.py
+++ b/microsetta_public_api/api/diversity/tests/test_alpha.py
@@ -68,7 +68,10 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
                 name='observed_otus'
             )
             metric = 'observed_otus'
-            response, code = alpha_group(self.post_body, metric, False, None)
+            response, code = alpha_group(self.post_body,
+                                         alpha_metric=metric,
+                                         summary_statistics=False,
+                                         return_raw=True)
 
         exp = {
             'alpha_metric': 'observed_otus',
@@ -84,10 +87,11 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
     def test_alpha_diversity_group_unknown_metric(self):
         with patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
             mock_metrics.return_value = ['metric-a', 'metric-b']
-            requested_metric = 'observed_otus'
-            response, code = alpha_group(self.post_body, requested_metric,
-                                         False,
-                                         None)
+            metric = 'observed_otus'
+            response, code = alpha_group(self.post_body,
+                                         alpha_metric=metric,
+                                         summary_statistics=False,
+                                         return_raw=True)
 
         api_out = json.loads(response.data)
         self.assertRegex(api_out['text'],

--- a/microsetta_public_api/api/diversity/tests/test_alpha.py
+++ b/microsetta_public_api/api/diversity/tests/test_alpha.py
@@ -115,7 +115,7 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
                 },
                 alpha_metric=metric,
                 summary_statistics=True,
-                percentiles=[100, 0, 50, 25],
+                percentiles=[100, 0, 50, 20],
                 return_raw=True,
             )
 
@@ -131,9 +131,9 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
                     'mean': 8,
                     'median': 7.75,
                     'std': sqrt(0.875),
-                    'group_size': 7,
-                    'percentile': [100, 0, 50, 25],
-                    'percentile_values': [9.5, 7, 7.75, 7.25]
+                    'group_size': 4,
+                    'percentile': [100, 0, 50, 20],
+                    'percentile_values': [9.5, 7, 7.75, 7.3]
                 }
             }
 
@@ -146,13 +146,16 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
             self.assertCountEqual(exp['group_summary'].keys(),
                                   obs['group_summary'].keys()
                                   )
-            npt.assert_array_almost_equal(exp.pop('percentile'),
-                                          obs.pop('percentile'))
-            npt.assert_array_almost_equal(exp.pop('percentile_values'),
-                                          obs.pop('percentile_values'))
+            gs_exp = exp['group_summary']
+            gs_obs = obs['group_summary']
+
+            npt.assert_array_almost_equal(gs_exp.pop('percentile'),
+                                          gs_obs.pop('percentile'))
+            npt.assert_array_almost_equal(gs_exp.pop('percentile_values'),
+                                          gs_obs.pop('percentile_values'))
             # checks of the numerical parts of the expected and observed are
             #  almost the same
-            pdt.assert_series_equal(pd.Series(exp), pd.Series(obs),
+            pdt.assert_series_equal(pd.Series(gs_exp), pd.Series(gs_obs),
                                     check_exact=False)
 
     def test_alpha_diversity_group_return_summary_only(self):
@@ -183,8 +186,8 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
                 },
                 alpha_metric=metric,
                 summary_statistics=True,
-                percentiles=[100, 0, 50, 25],
-                return_raw=True,
+                percentiles=[100, 0, 50, 20],
+                return_raw=False,
             )
 
             exp = {
@@ -193,9 +196,9 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
                     'mean': 8,
                     'median': 7.75,
                     'std': sqrt(0.875),
-                    'group_size': 7,
-                    'percentile': [100, 0, 50, 25],
-                    'percentile_values': [9.5, 7, 7.75, 7.25]
+                    'group_size': 4,
+                    'percentile': [100, 0, 50, 20],
+                    'percentile_values': [9.5, 7, 7.75, 7.3]
                 }
             }
 
@@ -206,13 +209,15 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
             self.assertCountEqual(exp['group_summary'].keys(),
                                   obs['group_summary'].keys()
                                   )
-            npt.assert_array_almost_equal(exp.pop('percentile'),
-                                          obs.pop('percentile'))
-            npt.assert_array_almost_equal(exp.pop('percentile_values'),
-                                          obs.pop('percentile_values'))
+            gs_exp = exp['group_summary']
+            gs_obs = obs['group_summary']
+            npt.assert_array_almost_equal(gs_exp.pop('percentile'),
+                                          gs_obs.pop('percentile'))
+            npt.assert_array_almost_equal(gs_exp.pop('percentile_values'),
+                                          gs_obs.pop('percentile_values'))
             # checks of the numerical parts of the expected and observed are
             #  almost the same
-            pdt.assert_series_equal(pd.Series(exp), pd.Series(obs),
+            pdt.assert_series_equal(pd.Series(gs_exp), pd.Series(gs_obs),
                                     check_exact=False)
 
     def test_alpha_diversity_group_percentiles_none(self):
@@ -250,8 +255,8 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
             obs = json.loads(response.data)
             self.assertIn('group_summary', obs)
             summary = obs['group_summary']
-            self.assertIn('percentiles', summary)
-            perc = summary['percentiles']
+            self.assertIn('percentile', summary)
+            perc = summary['percentile']
             # check default value of percentiles is returned
             npt.assert_array_almost_equal(perc, list(range(10, 91, 10)))
 

--- a/microsetta_public_api/api/diversity/tests/test_alpha.py
+++ b/microsetta_public_api/api/diversity/tests/test_alpha.py
@@ -1,0 +1,127 @@
+from microsetta_public_api.repo._alpha_repo import AlphaRepo
+from microsetta_public_api.api.diversity.alpha import (
+    available_metrics_alpha, get_alpha, alpha_group
+)
+from unittest.mock import patch, PropertyMock
+import pandas as pd
+import json
+
+from microsetta_public_api.utils.testing import MockedJsonifyTestCase
+
+
+class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.post_body = {'sample_ids': ['sample-foo-bar',
+                                        'sample-baz-bat']
+                         }
+
+    def test_alpha_diveristy_available_metrics(self):
+
+        with patch('microsetta_public_api.repo._alpha_repo.AlphaRepo'
+                   '.resources', new_callable=PropertyMock
+                   ) as mock_resources:
+            mock_resources.return_value = {
+                'faith_pd': '/some/path', 'chao1': '/some/other/path',
+            }
+            exp_metrics = ['faith_pd', 'chao1']
+            response, code = available_metrics_alpha()
+            obs = json.loads(response)
+            self.assertIn('alpha_metrics', obs)
+            self.assertListEqual(exp_metrics, obs['alpha_metrics'])
+
+    def test_alpha_diversity_single_sample(self):
+        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method, \
+                patch.object(AlphaRepo, 'exists') as mock_exists:
+            mock_exists.return_value = [True]
+            mock_method.return_value = pd.Series({
+                'sample-foo-bar': 8.25}, name='observed_otus')
+            response, code = get_alpha('sample-foo-bar', 'observed_otus')
+
+        exp = {
+            'sample_id': 'sample-foo-bar',
+            'alpha_metric': 'observed_otus',
+            'data': 8.25,
+        }
+        obs = json.loads(response)
+        self.assertDictEqual(exp, obs)
+        self.assertEqual(code, 200)
+
+    def test_alpha_diversity_unknown_id(self):
+        with patch.object(AlphaRepo, 'exists') as mock_exists:
+            mock_exists.return_value = [False]
+            response, code = get_alpha('sample-foo-bar', 'observed-otus')
+
+        self.assertRegex(response,
+                         "Sample ID not found.")
+        self.assertEqual(code, 404)
+
+    def test_alpha_diversity_group(self):
+        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method, \
+                patch.object(AlphaRepo, 'exists') as mock_exists, \
+                patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
+            mock_metrics.return_value = ['observed_otus']
+            mock_exists.return_value = [True, True]
+            mock_method.return_value = pd.Series({
+                'sample-foo-bar': 8.25, 'sample-baz-bat': 9.01},
+                name='observed_otus'
+            )
+            metric = 'observed_otus'
+            response, code = alpha_group(self.post_body, metric, False, None)
+
+        exp = {
+            'alpha_metric': 'observed_otus',
+            'alpha_diversity': {'sample-foo-bar': 8.25,
+                                'sample-baz-bat': 9.01,
+                                }
+        }
+        obs = json.loads(response.data)
+
+        self.assertDictEqual(exp, obs)
+        self.assertEqual(code, 200)
+
+    def test_alpha_diversity_group_unknown_metric(self):
+        with patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
+            mock_metrics.return_value = ['metric-a', 'metric-b']
+            requested_metric = 'observed_otus'
+            response, code = alpha_group(self.post_body, requested_metric,
+                                         False,
+                                         None)
+
+        api_out = json.loads(response.data)
+        self.assertRegex(api_out['text'],
+                         r"Requested metric: 'observed_otus' is unavailable. "
+                         r"Available metrics: \[(.*)\]")
+        self.assertEqual(code, 404)
+
+    def test_alpha_diversity_group_unknown_sample(self):
+        # One ID not found (out of two)
+        with patch.object(AlphaRepo, 'exists') as mock_exists, \
+                patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
+            mock_metrics.return_value = ['observed_otus']
+            mock_exists.side_effect = [True, False]
+            response, code = alpha_group(self.post_body, 'observed_otus',
+                                         )
+
+        api_out = json.loads(response.data)
+        self.assertListEqual(api_out['missing_ids'],
+                             ['sample-baz-bat'])
+        self.assertRegex(api_out['text'],
+                         r'Sample ID\(s\) not found.')
+        self.assertEqual(code, 404)
+
+        # Multiple IDs do not exist
+        with patch.object(AlphaRepo, 'exists') as mock_exists, \
+                patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
+            mock_metrics.return_value = ['observed_otus']
+            mock_exists.side_effect = [False, False]
+            response, code = alpha_group(self.post_body, 'observed_otus',
+                                         )
+        api_out = json.loads(response.data)
+        self.assertListEqual(api_out['missing_ids'],
+                             ['sample-foo-bar',
+                              'sample-baz-bat'])
+        self.assertRegex(api_out['text'],
+                         r'Sample ID\(s\) not found.')
+        self.assertEqual(code, 404)

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -10,6 +10,8 @@ paths:
   '/diversity/metrics/alpha/available':
     get:
       operationId: microsetta_public_api.api.diversity.alpha.available_metrics_alpha
+      tags:
+        - Diversity
       summary: Get available alpha diversity metrics
       description: Get available alpha diversity metrics
       responses:
@@ -74,10 +76,16 @@ paths:
           name: summary_statistics
           schema:
             type: boolean
-            default: false
+            default: true
           description: >
             Indicates whether summary statistics should be returned.
-            If false, raw alpha diversity will be returned instead.
+        - in: query
+          name: return_raw
+          schema:
+            type: boolean
+            default: false
+          description: >
+            Indicates whether raw alpha diversity values should be returned.
         - in: query
           name: percentiles
           explode: false

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -70,6 +70,22 @@ paths:
 
       parameters:
         - $ref: '#/components/parameters/alpha_metric'
+        - in: query
+          name: summary_statistics
+          schema:
+            type: boolean
+            default: false
+          description: Indicates whether summary statistics should be returned with the alpha diversity
+        - in: query
+          name: percentiles
+          schema:
+            type: array
+            items:
+              type: number
+              nullable: true
+            default: null
+            nullable: true
+          required: false
 
       requestBody:
         content:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -102,7 +102,7 @@ paths:
           description: >
             Percentiles that should be returned. If not specified, then
             `10,20,30,40,50,60,70,80,90` will be used.
-            Ignored if `summary_statistcs=true`.
+            Ignored if `summary_statistics=false`.
 
       requestBody:
         content:
@@ -201,6 +201,9 @@ paths:
 
         '404':
           $ref: '#/components/responses/404NotFound'
+        '400':
+          description: >
+            Either `summary_statistics`, `return_raw`, or both are required to be true.
 
 components:
   parameters:

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -270,6 +270,17 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
             )
             self.assertEqual(response.status_code, 200)
 
+            self.mock_method.return_value = jsonify(
+                error=400, text='at least one of summary_statistics'
+                                'and return_raw should be true'), 400
+            response = self.client.post(
+                '/api/diversity/alpha_group/observed_otus'
+                '?summary_statistics=true',
+                content_type='application/json',
+                data=json.dumps(self.request_content)
+            )
+            self.assertEqual(response.status_code, 400)
+
     def _minimal_query(self):
         minimal_query = '/api/diversity/alpha_group/observed_otus'
         return self.client.post(minimal_query,

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -8,7 +8,6 @@ class AlphaDiversityTestCase(FlaskTests):
 
     def setUp(self):
         super().setUp()
-        self.app_context = self.app.app.app_context
         self.request_content = {
                                 'sample_ids': ['sample-foo-bar',
                                                'sample-baz-bat'],

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -1,35 +1,19 @@
-from unittest import TestCase
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch
+from flask import jsonify
 import json
-import pandas as pd
-
-import microsetta_public_api
-import microsetta_public_api.server
-from microsetta_public_api.repo._alpha_repo import AlphaRepo
-
-
-class FlaskTests(TestCase):
-
-    def setUp(self):
-
-        self.app, self.client = self.build_app_test_client()
-
-    @staticmethod
-    def build_app_test_client():
-        app = microsetta_public_api.server.build_app()
-        client = app.app.test_client()
-        return app, client
+from microsetta_public_api.utils.testing import FlaskTests
 
 
 class AlphaDiversityTests(FlaskTests):
 
-    def test_alpha_diversity_available_metrics(self):
-        with patch('microsetta_public_api.repo._alpha_repo.AlphaRepo'
-                   '.resources', new_callable=PropertyMock
-                   ) as mock_resources:
-            mock_resources.return_value = {
-                'faith_pd': '/some/path', 'chao1': '/some/other/path',
-            }
+    def test_alpha_diversity_available_metrics_api(self):
+        with patch('microsetta_public_api.api.diversity.alpha'
+                   '.available_metrics_alpha'
+                   ) as mock_resources, self.app.app.app_context():
+            mock_resources.return_value = jsonify({
+                 'alpha_metrics': ['faith_pd', 'chao1']
+            }), 200
+
             _, self.client = self.build_app_test_client()
 
             exp_metrics = ['faith_pd', 'chao1']
@@ -39,33 +23,73 @@ class AlphaDiversityTests(FlaskTests):
             obs = json.loads(response.data)
             self.assertIn('alpha_metrics', obs)
             self.assertListEqual(exp_metrics, obs['alpha_metrics'])
+            self.assertEqual(response.status_code, 200)
 
-    def test_alpha_diversity_single_sample(self):
-        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method,\
-                patch.object(AlphaRepo, 'exists') as mock_exists:
-            mock_exists.return_value = [True]
-            mock_method.return_value = pd.Series({
-                'sample-foo-bar': 8.25}, name='observed_otus')
+            mock_resources.return_value = jsonify({
+                'alpha_metrics': []
+            }), 200
+            response = self.client.get(
+                '/api/diversity/metrics/alpha/available')
+
+            obs = json.loads(response.data)
+            self.assertIn('alpha_metrics', obs)
+            self.assertListEqual([], obs['alpha_metrics'])
+            self.assertEqual(response.status_code, 200)
+
+    def test_alpha_diversity_available_metrics_api_bad_response(self):
+        with patch('microsetta_public_api.api.diversity.alpha'
+                   '.available_metrics_alpha'
+                   ) as mock_resources, self.app.app.app_context():
+            mock_resources.return_value = jsonify({
+                'some wrong keyword': ['faith_pd', 'chao1']
+            }), 200
 
             _, self.client = self.build_app_test_client()
 
             response = self.client.get(
+                '/api/diversity/metrics/alpha/available')
+
+            self.assertEqual(response.status_code, 500)
+            mock_resources.return_value = jsonify({
+                'some wrong additional keyword': ['faith_pd', 'chao1'],
+                'alpha_metrics': ['faith_pd', 'chao1'],
+            }), 200
+            self.assertEqual(response.status_code, 500)
+            mock_resources.return_value = jsonify({
+                'alpha_metrics': 'faith_pd',
+            }), 200
+            self.assertEqual(response.status_code, 500)
+
+    def test_alpha_diversity_single_sample_api(self):
+        with patch('microsetta_public_api.api.diversity.alpha'
+                   '.get_alpha'
+                   ) as mock_method, self.app.app.app_context():
+
+            exp = {
+                'sample_id': 'sample-foo-bar',
+                'alpha_metric': 'observed_otus',
+                'data': 8.25,
+            }
+            mock_output = jsonify(exp), 200
+            mock_method.return_value = mock_output
+
+            _, self.client = self.build_app_test_client()
+            response = self.client.get(
                 '/api/diversity/alpha/observed_otus/sample-foo-bar')
 
-        exp = {
-            'sample_id': 'sample-foo-bar',
-            'alpha_metric': 'observed_otus',
-            'data': 8.25,
-        }
-        obs = json.loads(response.data)
+            obs = json.loads(response.data)
 
-        self.assertDictEqual(exp, obs)
-        self.assertEqual(response.status_code, 200)
+            self.assertDictEqual(exp, obs)
+            self.assertEqual(response.status_code, 200)
 
-    def test_alpha_diversity_unknown_id(self):
-        with patch.object(AlphaRepo, 'exists') as mock_exists:
-            mock_exists.return_value = [False]
+    def test_alpha_diversity_unknown_id_api(self):
+        with patch('microsetta_public_api.api.diversity.alpha'
+                   '.get_alpha'
+                   ) as mock_method, self.app.app.app_context():
 
+            mock_method.return_value = jsonify(error=404, text="Sample ID "
+                                                               "not found."), \
+                                       404
             _, self.client = self.build_app_test_client()
 
             response = self.client.get(
@@ -75,16 +99,17 @@ class AlphaDiversityTests(FlaskTests):
                          "Sample ID not found.")
         self.assertEqual(response.status_code, 404)
 
-    def test_alpha_diversity_group(self):
-        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method, \
-                patch.object(AlphaRepo, 'exists') as mock_exists, \
-                patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
-            mock_metrics.return_value = ['observed_otus']
-            mock_exists.return_value = [True, True]
-            mock_method.return_value = pd.Series({
-                'sample-foo-bar': 8.25, 'sample-baz-bat': 9.01},
-                name='observed_otus'
-                )
+    def test_alpha_diversity_group_api(self):
+        with patch('microsetta_public_api.api.diversity.alpha'
+                   '.alpha_group'
+                   ) as mock_method, self.app.app.app_context():
+            exp = {
+                'alpha_metric': 'observed_otus',
+                'alpha_diversity': {'sample-foo-bar': 8.25,
+                                    'sample-baz-bat': 9.01,
+                                    }
+            }
+            mock_method.return_value = jsonify(exp), 200
 
             _, self.client = self.build_app_test_client()
 
@@ -96,43 +121,21 @@ class AlphaDiversityTests(FlaskTests):
                                  })
             )
 
-        exp = {
-            'alpha_metric': 'observed_otus',
-            'alpha_diversity': {'sample-foo-bar': 8.25,
-                                'sample-baz-bat': 9.01,
-                                }
-        }
-        obs = json.loads(response.data)
+            obs = json.loads(response.data)
 
-        self.assertDictEqual(exp, obs)
-        self.assertEqual(response.status_code, 200)
+            self.assertDictEqual(exp, obs)
+            self.assertEqual(response.status_code, 200)
 
-    def test_alpha_diversity_group_unknown_metric(self):
-        # One ID not found (out of two)
-        with patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
-            mock_metrics.return_value = ['metric-a', 'metric-b']
+    def test_alpha_diversity_group_unknown_metric_api(self):
+        with patch('microsetta_public_api.api.diversity.alpha'
+                   '.alpha_group'
+                   ) as mock_method, self.app.app.app_context():
 
-            _, self.client = self.build_app_test_client()
-
-            response = self.client.post(
-                '/api/diversity/alpha_group/observed_otus',
-                content_type='application/json',
-                data=json.dumps({'metric': 'observed_otus',
-                                 'sample_ids': ['sample-foo-bar',
-                                                'sample-baz-bat']
-                                 })
-            )
-        api_out = json.loads(response.data.decode())
-        self.assertRegex(api_out['text'],
-                         r"Requested metric: 'observed_otus' is unavailable. "
-                         r"Available metrics: \[(.*)\]")
-
-    def test_alpha_diversity_group_unknown_sample(self):
-        # One ID not found (out of two)
-        with patch.object(AlphaRepo, 'exists') as mock_exists, \
-                patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
-            mock_metrics.return_value = ['observed_otus']
-            mock_exists.side_effect = [True, False]
+            available_metrics = ['metric1', 'metric2']
+            exp = dict(error=404, text=f"Requested metric: 'observed_otus' "
+                                       f"is unavailable. Available metrics: "
+                                       f"{available_metrics}")
+            mock_method.return_value = jsonify(exp), 404
 
             _, self.client = self.build_app_test_client()
 
@@ -145,17 +148,19 @@ class AlphaDiversityTests(FlaskTests):
                                  })
             )
         api_out = json.loads(response.data.decode())
-        self.assertListEqual(api_out['missing_ids'],
-                             ['sample-baz-bat'])
-        self.assertRegex(api_out['text'],
-                         r'Sample ID\(s\) not found.')
+        self.assertEqual(api_out['text'],
+                         exp['text'])
         self.assertEqual(response.status_code, 404)
 
-        # Multiple IDs do not exist
-        with patch.object(AlphaRepo, 'exists') as mock_exists, \
-                patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
-            mock_metrics.return_value = ['observed_otus']
-            mock_exists.side_effect = [False, False]
+    def test_alpha_diversity_group_unknown_sample_api(self):
+        with patch('microsetta_public_api.api.diversity.alpha'
+                   '.alpha_group'
+                   ) as mock_method, self.app.app.app_context():
+            missing_ids = ['sample-baz-bat']
+            exp = dict(missing_ids=missing_ids,
+                       error=404, text="Sample ID(s) not found for "
+                                       "metric: observed_otus")
+            mock_method.return_value = jsonify(exp), 404
 
             _, self.client = self.build_app_test_client()
 
@@ -167,10 +172,28 @@ class AlphaDiversityTests(FlaskTests):
                                                 'sample-baz-bat']
                                  })
             )
-        api_out = json.loads(response.data.decode())
-        self.assertListEqual(api_out['missing_ids'],
-                             ['sample-foo-bar',
-                              'sample-baz-bat'])
-        self.assertRegex(api_out['text'],
-                         r'Sample ID\(s\) not found.')
-        self.assertEqual(response.status_code, 404)
+            api_out = json.loads(response.data.decode())
+            self.assertEqual(api_out, exp)
+            self.assertEqual(response.status_code, 404)
+
+    def test_alpha_diversity_group_unknown_sample_api_bad_response(self):
+        with patch('microsetta_public_api.api.diversity.alpha'
+                   '.alpha_group'
+                   ) as mock_method, self.app.app.app_context():
+            bad_missing_ids = 'sample-baz-bat'
+            exp = dict(missing_ids=bad_missing_ids,
+                       error=404, text="Sample ID(s) not found for "
+                                       "metric: observed_otus")
+            mock_method.return_value = jsonify(exp), 404
+
+            _, self.client = self.build_app_test_client()
+
+            response = self.client.post(
+                '/api/diversity/alpha_group/observed_otus',
+                content_type='application/json',
+                data=json.dumps({'metric': 'observed_otus',
+                                 'sample_ids': ['sample-foo-bar',
+                                                'sample-baz-bat']
+                                 })
+            )
+            self.assertEqual(response.status_code, 500)

--- a/microsetta_public_api/models/_alpha.py
+++ b/microsetta_public_api/models/_alpha.py
@@ -165,7 +165,7 @@ class Alpha(ModelBase):
                              alpha_metric=self._series.name,
                              alpha_diversity=vals.to_dict())
 
-    def get_group(self, ids: List[str], name: str = None) -> GroupAlpha:
+    def get_group(self, ids: List[str] = None, name: str = None) -> GroupAlpha:
         """Get group values
 
         Parameters
@@ -188,6 +188,14 @@ class Alpha(ModelBase):
         GroupAlpha
             The corresponding distribution or individual data
         """
+        if ids is None:
+            ids = self._get_sample_ids()
+        elif len(ids) == 1:
+            name = ids[0]
+        else:
+            if name is None:
+                raise ValueError("Name not specified.")
+
         try:
             vals = self._series.loc[ids]
         except KeyError:
@@ -198,7 +206,7 @@ class Alpha(ModelBase):
 
         if len(ids) == 1:
             std = 0.
-            return GroupAlpha(name=ids[0],
+            return GroupAlpha(name=name,
                               alpha_metric=self._series.name,
                               mean=mean,
                               median=median,
@@ -219,4 +227,4 @@ class Alpha(ModelBase):
                               std=std,
                               group_size=len(vals),
                               percentile=self._percentiles,
-                              percentile_values=percentile_values)
+                              percentile_values=list(percentile_values))

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -32,6 +32,7 @@ class FlaskTests(TestCase):
     def setUp(self):
 
         self.app, self.client = self.build_app_test_client()
+        self.app_context = self.app.app.app_context
 
     @staticmethod
     def build_app_test_client():

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -1,8 +1,15 @@
-import unittest
+import functools
+import json
+import types
 import tempfile
+from unittest.case import TestCase
+
+import microsetta_public_api
+import microsetta_public_api.server
+from microsetta_public_api.api.diversity import alpha as alpha_imp
 
 
-class TempfileTestCase(unittest.TestCase):
+class TempfileTestCase(TestCase):
 
     def setUp(self):
         self._tempfiles = []
@@ -18,3 +25,77 @@ class TempfileTestCase(unittest.TestCase):
     def tearDown(self):
         for tempfile_ in self._tempfiles:
             tempfile_.close()
+
+
+class FlaskTests(TestCase):
+
+    def setUp(self):
+
+        self.app, self.client = self.build_app_test_client()
+
+    @staticmethod
+    def build_app_test_client():
+        app = microsetta_public_api.server.build_app()
+        client = app.app.test_client()
+        return app, client
+
+
+def _copy_func(f, name=None):
+    """
+    Based on https://stackoverflow.com/q/13503079
+    """
+    g = types.FunctionType(f.__code__, f.__globals__, name or f.__name__,
+                           argdefs=f.__defaults__, closure=f.__closure__)
+    g = functools.update_wrapper(g, f)
+    g.__kwdefaults__ = f.__kwdefaults__
+    return g
+
+
+class MockedResponse(str):
+
+    def __init__(self, data):
+        super().__init__()
+        self.data = data
+
+    def __eq__(self, other):
+        if isinstance(other, MockedResponse):
+            return self.data == other.data
+        else:
+            return self.data == other
+
+
+def mocked_jsonify(*args, **kwargs):
+    """Can be used to replace flask.jsonify, since it does not work
+    outside of a application context
+
+    From the flask docs:
+        1. Single argument: Passed straight through to dumps
+        2. Multiple arguments: converted to array and passed to dumps
+        3. Multiple kwargs: converted to a dict and passed to dumps
+        4. Both args and kwargs: behavior undefined and will throw an exception
+
+    Additionally, a _MockedWebResponse object the
+    """
+    # need to return an object so its attributes can be set (like in get_alpha)
+    def dump(data):
+        return MockedResponse(json.dumps(data))
+    if len(args) == 1 and len(kwargs) == 0:
+        return dump(*args)
+    elif len(args) > 1 and len(kwargs) == 0:
+        return dump([arg for arg in args])
+    elif len(args) == 0 and len(kwargs) > 0:
+        return dump(kwargs)
+    else:
+        raise TypeError(f"mocked_jsonify got an unexpected combination of "
+                        f"args and kwargs. Got args={args}, kwargs={kwargs}.")
+
+
+class MockedJsonifyTestCase(TestCase):
+
+    def setUp(self):
+        # monkey patch jsonify, then restore it after these tests are complete
+        self.old_jsonify = _copy_func(alpha_imp.jsonify)
+        alpha_imp.jsonify = mocked_jsonify
+
+    def tearDown(self):
+        alpha_imp.jsonify = self.old_jsonify

--- a/microsetta_public_api/utils/tests/test_utils.py
+++ b/microsetta_public_api/utils/tests/test_utils.py
@@ -1,0 +1,13 @@
+from unittest.case import TestCase
+
+from microsetta_public_api.utils.testing import mocked_jsonify
+
+
+class MockedJsonifyTests(TestCase):
+
+    def test_mock_jsonify(self):
+        mocked_jsonify('a')
+        mocked_jsonify(a='a', b='b')
+        mocked_jsonify('a', 'b', 'c')
+        with self.assertRaises(TypeError):
+            mocked_jsonify({'a': 'b', 'c': 'd'}, e='f')


### PR DESCRIPTION
This one got a bit of scope creep in the tests 😅 

This PR adds Alpha diversity group summaries into the REST API, as well as some testing utilities and improved separation of the API and implementation layers in testing of `alpha_group`.

The major API changes (open to more consideration) include:
* Adding ability to return group summaries from `/api/diversity/alpha_group/{alpha_metric}`
    * As it is currently written, a user can ask for raw values, a summary, or both (with option to change percentiles in summary). 
    * Posts that ask for neither raw values or a summary (e.g., `/api/diversity/alpha_group/{alpha_metric}?return_raw=false&summary_statistics=false`) will give a bad request error.
    * By default, summary statistics will be returned and raw values will not be.