### PR TITLE
Taxonomy implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm project settings
+.idea

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ in a configuration `JSON`. The value is expected to be a dictionary of `"<metric
 where `"<metric>"` is the name of the metric stored by the QZA and `"</file/path/name.qza>"` is a path to the QZA
 on the host server.
 
+The server can also be configured to serve information from feature tables with corresponding taxonomic
+feature data. Tables can either be QZA `FeatureTable`'s or biom tables. If a `biom` table is supplied,
+the `"table-format": "biom"` option must be specified. Taxonomy data is accepted with the
+`"feature-data-taxonomy"` keyword, which should correspond to the filepath to a QIIME2 `FeatureData[Taxonomy]`.
+
 `sample_config.json`:
 ```json
 {
@@ -51,6 +56,13 @@ on the host server.
     "faith_pd": "/path/to/faith_pd.qza",
     "observed_otus": "/path/to/observed/otus/metric.qza",
     "chao1": "/some/other/path/values.qza"
+  },
+  "table_resources": {
+    "taxonomy": {
+      "table": "/path/to/table.biom",
+      "table-format": "biom",
+      "feature-data-taxonomy": "/path/to/a/taxonomy-data.qza"
+    }
   }
 }
 ```

--- a/microsetta_public_api/api/__init__.py
+++ b/microsetta_public_api/api/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['diversity', 'taxonomy']

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -1,16 +1,12 @@
-from flask import jsonify as flask_jsonify
 from microsetta_public_api.models._alpha import Alpha
 from microsetta_public_api.repo._alpha_repo import AlphaRepo
-
-
-def jsonify(*args, **kwargs):
-    return flask_jsonify(*args, **kwargs)
+from microsetta_public_api.utils import jsonify
 
 
 def get_alpha(sample_id, alpha_metric):
     alpha_repo = AlphaRepo()
     if not all(alpha_repo.exists([sample_id], alpha_metric)):
-        return jsonify(error=404, text="Sample ID not found."),\
+        return jsonify(error=404, text="Sample ID not found."), \
                404
     alpha_series = alpha_repo.get_alpha_diversity([sample_id],
                                                   alpha_metric)
@@ -53,8 +49,8 @@ def alpha_group(body, alpha_metric, summary_statistics=True,
     if len(missing_ids) > 0:
         return jsonify(missing_ids=missing_ids,
                        error=404, text=f"Sample ID(s) not found for "
-                                       f"metric: {alpha_metric}"),\
-                       404
+                                       f"metric: {alpha_metric}"), \
+               404
 
     # retrieve the alpha diversity for each sample
     alpha_series = alpha_repo.get_alpha_diversity(sample_ids,

--- a/microsetta_public_api/api/diversity/tests/test_alpha.py
+++ b/microsetta_public_api/api/diversity/tests/test_alpha.py
@@ -1,8 +1,8 @@
 from microsetta_public_api.repo._alpha_repo import AlphaRepo
+from unittest.mock import patch, PropertyMock
 from microsetta_public_api.api.diversity.alpha import (
     available_metrics_alpha, get_alpha, alpha_group
 )
-from unittest.mock import patch, PropertyMock
 import numpy.testing as npt
 import pandas as pd
 import pandas.testing as pdt
@@ -13,6 +13,10 @@ from microsetta_public_api.utils.testing import MockedJsonifyTestCase
 
 
 class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
+
+    # need to choose where jsonify is being loaded from
+    # see https://stackoverflow.com/a/46465025
+    jsonify_to_patch = 'microsetta_public_api.api.diversity.alpha.jsonify'
 
     @classmethod
     def setUpClass(cls):

--- a/microsetta_public_api/api/diversity/tests/test_alpha.py
+++ b/microsetta_public_api/api/diversity/tests/test_alpha.py
@@ -67,6 +67,27 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
                          "Sample ID not found.")
         self.assertEqual(code, 404)
 
+    def test_alpha_diversity_improper_parameters(self):
+        with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method, \
+                patch.object(AlphaRepo, 'exists') as mock_exists, \
+                patch.object(AlphaRepo, 'available_metrics') as mock_metrics:
+            mock_metrics.return_value = ['observed_otus']
+            mock_exists.return_value = [True, True]
+            mock_method.return_value = pd.Series({
+                'sample-foo-bar': 8.25, 'sample-baz-bat': 9.01},
+                name='observed_otus'
+            )
+            metric = 'observed_otus'
+            response, code = alpha_group(self.post_body,
+                                         alpha_metric=metric,
+                                         summary_statistics=False,
+                                         return_raw=False)
+            obs = json.loads(response)
+            self.assertEqual(400, code)
+            self.assertEqual('Either `summary_statistics`, `return_raw`, '
+                             'or both are required to be true.',
+                             obs['text'])
+
     def test_alpha_diversity_group_return_raw_only(self):
         with patch.object(AlphaRepo, 'get_alpha_diversity') as mock_method, \
                 patch.object(AlphaRepo, 'exists') as mock_exists, \

--- a/microsetta_public_api/api/diversity/tests/test_alpha.py
+++ b/microsetta_public_api/api/diversity/tests/test_alpha.py
@@ -16,7 +16,10 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
 
     # need to choose where jsonify is being loaded from
     # see https://stackoverflow.com/a/46465025
-    jsonify_to_patch = 'microsetta_public_api.api.diversity.alpha.jsonify'
+    jsonify_to_patch = [
+        'microsetta_public_api.api.diversity.alpha.jsonify',
+        'microsetta_public_api.utils._utils.jsonify',
+    ]
 
     @classmethod
     def setUpClass(cls):
@@ -276,7 +279,7 @@ class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
         api_out = json.loads(response.data)
         self.assertRegex(api_out['text'],
                          r"Requested metric: 'observed_otus' is unavailable. "
-                         r"Available metrics: \[(.*)\]")
+                         r"Available metric\(s\): \[(.*)\]")
         self.assertEqual(code, 404)
 
     def test_alpha_diversity_group_unknown_sample(self):

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -108,18 +108,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - sample_ids
-              properties:
-                sample_ids:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/sample_id'
-                  example:
-                    - "sample1"
-                    - "sample2"
-                    - "sample3"
+              $ref: "#/components/schemas/sampleIdList"
 
       responses:
         '200':
@@ -251,18 +240,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - sample_ids
-              properties:
-                sample_ids:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/sample_id'
-                  example:
-                    - "sample1"
-                    - "sample2"
-                    - "sample3"
+              $ref: "#/components/schemas/sampleIdList"
 
       responses:
         '200':
@@ -329,6 +307,19 @@ components:
     sample_id:
       type: string
       example: "sample_15"
+    sampleIdList:
+      type: object
+      required:
+        - sample_ids
+      properties:
+        sample_ids:
+          type: array
+          items:
+            $ref: '#/components/schemas/sample_id'
+          example:
+            - "sample1"
+            - "sample2"
+            - "sample3"
 
   responses:
     404NotFound:       # Can be referenced as '#/components/responses/404NotFound'

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -196,7 +196,7 @@ paths:
 
   '/taxonomy/available':
     get:
-      operationId: microsetta_public_api.api.taxonomy.resources_available
+      operationId: microsetta_public_api.api.taxonomy.resources
       tags:
         - Taxonomy
       summary: Get list of available taxonomy resources

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -279,6 +279,7 @@ paths:
                     example:
                       - 0.05
                       - 0.11
+                    nullable: true
 
         '404':
           $ref: '#/components/responses/404NotFound'

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -1,3 +1,4 @@
+import json
 from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
 from microsetta_public_api.utils import jsonify
 from microsetta_public_api.models._taxonomy import Taxonomy
@@ -7,13 +8,13 @@ from microsetta_public_api.utils._utils import (validate_resource,
 
 
 def summarize_group(body, resource):
-    sample_ids = body['sample_ids']
+    sample_ids = json.loads(body)['sample_ids']
     return _summarize_group(sample_ids, resource)
 
 
 def _summarize_group(sample_ids, table_name):
     taxonomy_repo = TaxonomyRepo()
-    available_resources = taxonomy_repo.available_resources()
+    available_resources = taxonomy_repo.resources()
 
     type_ = 'resource'
     missing_resource = validate_resource(available_resources, table_name,
@@ -28,21 +29,21 @@ def _summarize_group(sample_ids, table_name):
     if missing_ids_msg:
         return missing_ids_msg
 
-    table = taxonomy_repo.table(sample_ids, table_name)
+    table = taxonomy_repo.table(table_name)
     features = taxonomy_repo.feature_data_taxonomy(table_name)
-    variances = taxonomy_repo.variances(sample_ids, table_name)
+    variances = taxonomy_repo.variances(table_name)
 
     taxonomy_ = Taxonomy(table, features, variances)
-    taxonomy_data = taxonomy_.get_group(sample_ids, '')
+    taxonomy_data = taxonomy_.get_group(sample_ids, '').to_dict()
     del taxonomy_data['name']
     del taxonomy_data['feature_ranks']
     response = jsonify(taxonomy_data)
     return response, 200
 
 
-def resources_available():
+def resources():
     taxonomy_repo = TaxonomyRepo()
     ret_val = {
-        'resources': taxonomy_repo.available_resources(),
+        'resources': taxonomy_repo.resources(),
     }
     return jsonify(ret_val), 200

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -1,4 +1,3 @@
-import json
 from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
 from microsetta_public_api.utils import jsonify
 from microsetta_public_api.models._taxonomy import Taxonomy
@@ -8,7 +7,7 @@ from microsetta_public_api.utils._utils import (validate_resource,
 
 
 def summarize_group(body, resource):
-    sample_ids = json.loads(body)['sample_ids']
+    sample_ids = body['sample_ids']
     return _summarize_group(sample_ids, resource)
 
 

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -1,6 +1,48 @@
+from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
+from microsetta_public_api.utils import jsonify
+from microsetta_public_api.models._taxonomy import Taxonomy
+from microsetta_public_api.utils._utils import (validate_resource,
+                                                check_missing_ids,
+                                                )
+
+
 def summarize_group(body, resource):
-    pass
+    sample_ids = body['sample_ids']
+    return _summarize_group(sample_ids, resource)
+
+
+def _summarize_group(sample_ids, table_name):
+    taxonomy_repo = TaxonomyRepo()
+    available_resources = taxonomy_repo.available_resources()
+
+    type_ = 'resource'
+    missing_resource = validate_resource(available_resources, table_name,
+                                         type_)
+    if missing_resource:
+        return missing_resource
+
+    missing_ids = [id_ for id_ in sample_ids if
+                   not taxonomy_repo.exists(id_, table_name)]
+
+    missing_ids_msg = check_missing_ids(missing_ids, table_name, type_)
+    if missing_ids_msg:
+        return missing_ids_msg
+
+    table = taxonomy_repo.table(sample_ids, table_name)
+    features = taxonomy_repo.feature_data_taxonomy(table_name)
+    variances = taxonomy_repo.variances(sample_ids, table_name)
+
+    taxonomy_ = Taxonomy(table, features, variances)
+    taxonomy_data = taxonomy_.get_group(sample_ids, '')
+    del taxonomy_data['name']
+    del taxonomy_data['feature_ranks']
+    response = jsonify(taxonomy_data)
+    return response, 200
 
 
 def resources_available():
-    pass
+    taxonomy_repo = TaxonomyRepo()
+    ret_val = {
+        'resources': taxonomy_repo.available_resources(),
+    }
+    return jsonify(ret_val), 200

--- a/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
@@ -1,0 +1,352 @@
+import biom
+import numpy as np
+import pandas as pd
+from numpy.testing import assert_allclose
+import json
+from unittest.mock import patch, PropertyMock
+from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
+from microsetta_public_api.utils.testing import MockedJsonifyTestCase
+from microsetta_public_api.api.taxonomy import (
+    resources, summarize_group, _summarize_group,
+)
+
+
+class TaxonomyImplementationTests(MockedJsonifyTestCase):
+
+    jsonify_to_patch = [
+        'microsetta_public_api.api.taxonomy.jsonify',
+        'microsetta_public_api.utils._utils.jsonify',
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.post_body = {'sample_ids': ['sample-1',
+                                        'sample-2',
+                                        ]}
+        cls.table = biom.Table(np.array([[0, 1, 2],
+                                         [2, 4, 6],
+                                         [3, 0, 1]]),
+                               ['feature-1', 'feature-2', 'feature-3'],
+                               ['sample-1', 'sample-2', 'sample-3'])
+        cls.taxonomy_df = pd.DataFrame([['feature-1', 'a; b; c', 0.123],
+                                        ['feature-2', 'a; b; c; d; e', 0.345],
+                                        ['feature-3', 'a; f; g; h', 0.678]],
+                                       columns=['Feature ID', 'Taxon',
+                                                'Confidence'])
+        cls.taxonomy_df.set_index('Feature ID', inplace=True)
+
+        cls.table2 = biom.Table(np.array([[0, 1, 2],
+                                          [2, 4, 6],
+                                          [3, 0, 1]]),
+                                ['feature-1', 'feature-X', 'feature-3'],
+                                ['sample-1', 'sample-2', 'sample-3'])
+        cls.taxonomy2_df = pd.DataFrame([['feature-1', 'a; b; c', 0.123],
+                                         ['feature-X', 'a; b; c; d; e', 0.34],
+                                         ['feature-3', 'a; f; g; h', 0.678]],
+                                        columns=['Feature ID', 'Taxon',
+                                                 'Confidence'])
+        cls.taxonomy2_df.set_index('Feature ID', inplace=True)
+
+        # variances
+        cls.table_vars = biom.Table(np.array([[0, 1, 2],
+                                              [2, 4, 6],
+                                              [3, 0, 1]]),
+                                    ['feature-1', 'feature-2', 'feature-3'],
+                                    ['sample-1', 'sample-2', 'sample-3'])
+
+    def setUp(self):
+        super().setUp()
+
+    def test_taxonomy_resources_available(self):
+        with patch.object(TaxonomyRepo, 'resources') as mock_resources:
+            mock_resources.return_value = [
+                'alpha', 'beta'
+            ]
+            exp_res = ['alpha', 'beta']
+            response, code = resources()
+
+        obs = json.loads(response)
+        self.assertEqual(code, 200)
+        self.assertIn('resources', obs)
+        self.assertCountEqual(exp_res, obs['resources'])
+
+    def test_taxonomy_unknown_resource(self):
+        with patch.object(TaxonomyRepo, 'resources') as mock_resources:
+            mock_resources.return_value = [
+                'alpha', 'beta'
+            ]
+            response, code = summarize_group(json.dumps(self.post_body),
+                                             'some-other-table'
+                                             )
+
+        api_out = json.loads(response.data)
+        self.assertRegex(api_out['text'],
+                         r"Requested resource: 'some-other-table' is "
+                         r"unavailable. "
+                         r"Available resource\(s\): \[(.*)\]")
+        self.assertEqual(code, 404)
+
+    def test_taxonomy_unknown_sample(self):
+        # One ID not found (out of two)
+        with patch.object(TaxonomyRepo, 'exists') as mock_exists, \
+                patch.object(TaxonomyRepo, 'resources') as mock_resources:
+            mock_resources.return_value = ['foo-table']
+            mock_exists.side_effect = [True, False]
+            response, code = summarize_group(json.dumps(
+                {'sample_ids': ['sample-1', 'sample-baz-bat']}), 'foo-table')
+
+        api_out = json.loads(response.data)
+        self.assertListEqual(api_out['missing_ids'],
+                             ['sample-baz-bat'])
+        self.assertRegex(api_out['text'],
+                         r'Sample ID\(s\) not found.')
+        self.assertEqual(code, 404)
+
+        # Multiple IDs do not exist
+        with patch.object(TaxonomyRepo, 'exists') as mock_exists, \
+                patch.object(TaxonomyRepo, 'resources') as mock_metrics:
+            mock_metrics.return_value = ['bar-table']
+            mock_exists.side_effect = [False, False]
+            response, code = summarize_group(
+                json.dumps({'sample_ids': ['sample-foo-bar',
+                                           'sample-baz-bat']}), 'bar-table')
+        api_out = json.loads(response.data)
+        self.assertListEqual(api_out['missing_ids'],
+                             ['sample-foo-bar',
+                              'sample-baz-bat'])
+        self.assertRegex(api_out['text'],
+                         r'Sample ID\(s\) not found.')
+        self.assertEqual(code, 404)
+
+    def test_taxonomy_summarize_group_simple(self):
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo.'
+                   'tables', new_callable=PropertyMock) as mock_tables:
+            mock_tables.return_value = {
+                'some-table': {
+                    'table': self.table,
+                    'feature-data-taxonomy': self.taxonomy_df,
+                },
+            }
+            response, code = summarize_group(json.dumps(self.post_body),
+                                             "some-table")
+        self.assertEqual(code, 200)
+        exp_keys = ['taxonomy', 'features', 'feature_values',
+                    'feature_variances']
+        obs = json.loads(response)
+
+        self.assertCountEqual(exp_keys, obs.keys())
+        self.assertEqual('((((feature-1,((feature-2)e)d)c)b,'
+                         '(((feature-3)h)g)f)a);',
+                         obs['taxonomy']
+                         )
+        self.assertListEqual(['feature-1', 'feature-2', 'feature-3'],
+                             obs['features'])
+        assert_allclose([1. / 10, 6. / 10, 3. / 10],
+                        obs['feature_values']
+                        )
+        assert_allclose([0, 0, 0],
+                        obs['feature_variances']
+                        )
+
+    def test_taxonomy_summarize_group_simple_with_variances(self):
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo.'
+                   'tables', new_callable=PropertyMock) as mock_tables:
+            mock_tables.return_value = {
+                'some-table': {
+                    'table': self.table,
+                    'feature-data-taxonomy': self.taxonomy_df,
+                    'variances': self.table_vars,
+                },
+            }
+            response, code = summarize_group(json.dumps(self.post_body),
+                                             "some-table")
+        self.assertEqual(code, 200)
+        exp_keys = ['taxonomy', 'features', 'feature_values',
+                    'feature_variances']
+        obs = json.loads(response)
+
+        self.assertCountEqual(exp_keys, obs.keys())
+        self.assertEqual('((((feature-1,((feature-2)e)d)c)b,'
+                         '(((feature-3)h)g)f)a);',
+                         obs['taxonomy']
+                         )
+        self.assertListEqual(['feature-1', 'feature-2', 'feature-3'],
+                             obs['features'])
+        assert_allclose([1. / 10, 6. / 10, 3. / 10],
+                        obs['feature_values']
+                        )
+        assert_allclose([0, 0, 0],
+                        obs['feature_variances']
+                        )
+
+    def test_taxonomy_summarize_group_one_sample_with_variance(self):
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo.'
+                   'tables', new_callable=PropertyMock) as mock_tables:
+            mock_tables.return_value = {
+                'some-table': {
+                    'table': self.table,
+                    'feature-data-taxonomy': self.taxonomy_df,
+                    'variances': self.table_vars,
+                },
+            }
+            response, code = summarize_group(
+                json.dumps({'sample_ids': ['sample-1']}), "some-table")
+
+        self.assertEqual(code, 200)
+        exp_keys = ['taxonomy', 'features', 'feature_values',
+                    'feature_variances']
+        obs = json.loads(response)
+
+        self.assertCountEqual(exp_keys, obs.keys())
+        self.assertEqual('((((((feature-2)e)d)c)b,(((feature-3)h)g)f)a);',
+                         obs['taxonomy']
+                         )
+        self.assertListEqual(['feature-2', 'feature-3'],
+                             obs['features'])
+        assert_allclose([2. / 5, 3. / 5],
+                        obs['feature_values']
+                        )
+        assert_allclose([2.0, 3.0],
+                        obs['feature_variances']
+                        )
+
+    def test_taxonomy_from_list_unknown_resource(self):
+        with patch.object(TaxonomyRepo, 'resources') as mock_resources:
+            mock_resources.return_value = [
+                'alpha', 'beta'
+            ]
+            response, code = _summarize_group(list(self.post_body.values()),
+                                              'some-other-table'
+                                              )
+
+        api_out = json.loads(response.data)
+        self.assertRegex(api_out['text'],
+                         r"Requested resource: 'some-other-table' is "
+                         r"unavailable. "
+                         r"Available resource\(s\): \[(.*)\]")
+        self.assertEqual(code, 404)
+
+    def test_taxonomy_from_list_unknown_sample(self):
+        # One ID not found (out of two)
+        with patch.object(TaxonomyRepo, 'exists') as mock_exists, \
+                patch.object(TaxonomyRepo, 'resources') as mock_resources:
+            mock_resources.return_value = ['foo-table']
+            mock_exists.side_effect = [True, False]
+            response, code = _summarize_group(
+                ['sample-1', 'sample-baz-bat'], 'foo-table')
+
+        api_out = json.loads(response.data)
+        self.assertListEqual(api_out['missing_ids'],
+                             ['sample-baz-bat'])
+        self.assertRegex(api_out['text'],
+                         r'Sample ID\(s\) not found.')
+        self.assertEqual(code, 404)
+
+        # Multiple IDs do not exist
+        with patch.object(TaxonomyRepo, 'exists') as mock_exists, \
+                patch.object(TaxonomyRepo, 'resources') as mock_metrics:
+            mock_metrics.return_value = ['bar-table']
+            mock_exists.side_effect = [False, False]
+            response, code = _summarize_group(
+                ['sample-foo-bar',
+                 'sample-baz-bat'], 'bar-table')
+        api_out = json.loads(response.data)
+        self.assertListEqual(api_out['missing_ids'],
+                             ['sample-foo-bar',
+                              'sample-baz-bat'])
+        self.assertRegex(api_out['text'],
+                         r'Sample ID\(s\) not found.')
+        self.assertEqual(code, 404)
+
+    def test_taxonomy_from_list_summarize_group_simple(self):
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo.'
+                   'tables', new_callable=PropertyMock) as mock_tables:
+            mock_tables.return_value = {
+                'some-table': {
+                    'table': self.table,
+                    'feature-data-taxonomy': self.taxonomy_df,
+                },
+            }
+            response, code = _summarize_group(self.post_body['sample_ids'],
+                                              "some-table")
+        self.assertEqual(code, 200)
+        exp_keys = ['taxonomy', 'features', 'feature_values',
+                    'feature_variances']
+        obs = json.loads(response)
+
+        self.assertCountEqual(exp_keys, obs.keys())
+        self.assertEqual('((((feature-1,((feature-2)e)d)c)b,'
+                         '(((feature-3)h)g)f)a);',
+                         obs['taxonomy']
+                         )
+        self.assertListEqual(['feature-1', 'feature-2', 'feature-3'],
+                             obs['features'])
+        assert_allclose([1. / 10, 6. / 10, 3. / 10],
+                        obs['feature_values']
+                        )
+        assert_allclose([0, 0, 0],
+                        obs['feature_variances']
+                        )
+
+    def test_taxonomy_from_list_summarize_group_simple_with_variances(self):
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo.'
+                   'tables', new_callable=PropertyMock) as mock_tables:
+            mock_tables.return_value = {
+                'some-table': {
+                    'table': self.table,
+                    'feature-data-taxonomy': self.taxonomy_df,
+                    'variances': self.table_vars,
+                },
+            }
+            response, code = _summarize_group(self.post_body['sample_ids'],
+                                              "some-table")
+        self.assertEqual(code, 200)
+        exp_keys = ['taxonomy', 'features', 'feature_values',
+                    'feature_variances']
+        obs = json.loads(response)
+
+        self.assertCountEqual(exp_keys, obs.keys())
+        self.assertEqual('((((feature-1,((feature-2)e)d)c)b,'
+                         '(((feature-3)h)g)f)a);',
+                         obs['taxonomy']
+                         )
+        self.assertListEqual(['feature-1', 'feature-2', 'feature-3'],
+                             obs['features'])
+        assert_allclose([1. / 10, 6. / 10, 3. / 10],
+                        obs['feature_values']
+                        )
+        assert_allclose([0, 0, 0],
+                        obs['feature_variances']
+                        )
+
+    def test_taxonomy_from_list_summarize_group_one_sample_with_variance(self):
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo.'
+                   'tables', new_callable=PropertyMock) as mock_tables:
+            mock_tables.return_value = {
+                'some-table': {
+                    'table': self.table,
+                    'feature-data-taxonomy': self.taxonomy_df,
+                    'variances': self.table_vars,
+                },
+            }
+            response, code = _summarize_group(
+                ['sample-1'], "some-table")
+
+        self.assertEqual(code, 200)
+        exp_keys = ['taxonomy', 'features', 'feature_values',
+                    'feature_variances']
+        obs = json.loads(response)
+
+        self.assertCountEqual(exp_keys, obs.keys())
+        self.assertEqual('((((((feature-2)e)d)c)b,(((feature-3)h)g)f)a);',
+                         obs['taxonomy']
+                         )
+        self.assertListEqual(['feature-2', 'feature-3'],
+                             obs['features'])
+        assert_allclose([2. / 5, 3. / 5],
+                        obs['feature_values']
+                        )
+        assert_allclose([2.0, 3.0],
+                        obs['feature_variances']
+                        )
+

--- a/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
@@ -337,4 +337,3 @@ class TaxonomyImplementationTests(MockedJsonifyTestCase):
         assert_allclose([2.0, 3.0],
                         obs['feature_variances']
                         )
-

--- a/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
@@ -35,18 +35,6 @@ class TaxonomyImplementationTests(MockedJsonifyTestCase):
                                                 'Confidence'])
         cls.taxonomy_df.set_index('Feature ID', inplace=True)
 
-        cls.table2 = biom.Table(np.array([[0, 1, 2],
-                                          [2, 4, 6],
-                                          [3, 0, 1]]),
-                                ['feature-1', 'feature-X', 'feature-3'],
-                                ['sample-1', 'sample-2', 'sample-3'])
-        cls.taxonomy2_df = pd.DataFrame([['feature-1', 'a; b; c', 0.123],
-                                         ['feature-X', 'a; b; c; d; e', 0.34],
-                                         ['feature-3', 'a; f; g; h', 0.678]],
-                                        columns=['Feature ID', 'Taxon',
-                                                 'Confidence'])
-        cls.taxonomy2_df.set_index('Feature ID', inplace=True)
-
         # variances
         cls.table_vars = biom.Table(np.array([[0, 1, 2],
                                               [2, 4, 6],

--- a/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
@@ -63,7 +63,7 @@ class TaxonomyImplementationTests(MockedJsonifyTestCase):
             mock_resources.return_value = [
                 'alpha', 'beta'
             ]
-            response, code = summarize_group(json.dumps(self.post_body),
+            response, code = summarize_group(self.post_body,
                                              'some-other-table'
                                              )
 
@@ -80,8 +80,8 @@ class TaxonomyImplementationTests(MockedJsonifyTestCase):
                 patch.object(TaxonomyRepo, 'resources') as mock_resources:
             mock_resources.return_value = ['foo-table']
             mock_exists.side_effect = [True, False]
-            response, code = summarize_group(json.dumps(
-                {'sample_ids': ['sample-1', 'sample-baz-bat']}), 'foo-table')
+            response, code = summarize_group(
+                {'sample_ids': ['sample-1', 'sample-baz-bat']}, 'foo-table')
 
         api_out = json.loads(response.data)
         self.assertListEqual(api_out['missing_ids'],
@@ -96,8 +96,8 @@ class TaxonomyImplementationTests(MockedJsonifyTestCase):
             mock_metrics.return_value = ['bar-table']
             mock_exists.side_effect = [False, False]
             response, code = summarize_group(
-                json.dumps({'sample_ids': ['sample-foo-bar',
-                                           'sample-baz-bat']}), 'bar-table')
+                {'sample_ids': ['sample-foo-bar',
+                                'sample-baz-bat']}, 'bar-table')
         api_out = json.loads(response.data)
         self.assertListEqual(api_out['missing_ids'],
                              ['sample-foo-bar',
@@ -115,7 +115,7 @@ class TaxonomyImplementationTests(MockedJsonifyTestCase):
                     'feature-data-taxonomy': self.taxonomy_df,
                 },
             }
-            response, code = summarize_group(json.dumps(self.post_body),
+            response, code = summarize_group(self.post_body,
                                              "some-table")
         self.assertEqual(code, 200)
         exp_keys = ['taxonomy', 'features', 'feature_values',
@@ -146,7 +146,7 @@ class TaxonomyImplementationTests(MockedJsonifyTestCase):
                     'variances': self.table_vars,
                 },
             }
-            response, code = summarize_group(json.dumps(self.post_body),
+            response, code = summarize_group(self.post_body,
                                              "some-table")
         self.assertEqual(code, 200)
         exp_keys = ['taxonomy', 'features', 'feature_values',
@@ -178,7 +178,7 @@ class TaxonomyImplementationTests(MockedJsonifyTestCase):
                 },
             }
             response, code = summarize_group(
-                json.dumps({'sample_ids': ['sample-1']}), "some-table")
+                {'sample_ids': ['sample-1']}, "some-table")
 
         self.assertEqual(code, 200)
         exp_keys = ['taxonomy', 'features', 'feature_values',

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -340,7 +340,7 @@ class TaxonomyResourcesAPITests(FlaskTests):
     def setUp(self):
         super().setUp()
         self.patcher = patch('microsetta_public_api.api.taxonomy'
-                             '.resources_available')
+                             '.resources')
         self.mock_method = self.patcher.start()
         self.url = '/api/taxonomy/available'
         _, self.client = self.build_app_test_client()

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -1,0 +1,206 @@
+import json
+import numpy as np
+import pandas as pd
+import biom
+from biom.util import biom_open
+from qiime2 import Artifact
+
+from microsetta_public_api import config
+from microsetta_public_api.resources import resources
+from microsetta_public_api.utils.testing import FlaskTests, \
+    TempfileTestCase, ConfigTestCase
+
+
+class IntegrationTests(FlaskTests, TempfileTestCase, ConfigTestCase):
+    def setUp(self):
+        ConfigTestCase.setUp(self)
+        FlaskTests.setUp(self)
+        TempfileTestCase.setUp(self)
+
+    def tearDown(self):
+        TempfileTestCase.tearDown(self)
+        FlaskTests.tearDown(self)
+        ConfigTestCase.tearDown(self)
+
+
+class TaxonomyIntegrationTests(IntegrationTests):
+
+    def setUp(self):
+        super().setUp()
+        self.table1_filename = self.create_tempfile(suffix='.qza').name
+        self.taxonomy1_filename = self.create_tempfile(suffix='.qza').name
+        self.table2_filename = self.create_tempfile(suffix='.qza').name
+        self.taxonomy2_filename = self.create_tempfile(suffix='.qza').name
+        self.table3_filename = self.create_tempfile(suffix='.qza').name
+        self.var_table_filename = self.create_tempfile(suffix='.qza').name
+        self.table_biom = self.create_tempfile(suffix='.biom').name
+
+        self.table = biom.Table(np.array([[0, 1, 2],
+                                          [2, 4, 6],
+                                          [3, 0, 1]]),
+                                ['feature-1', 'feature-2', 'feature-3'],
+                                ['sample-1', 'sample-2', 'sample-3'])
+
+        self.taxonomy_df = pd.DataFrame([['feature-1', 'a; b; c', 0.123],
+                                         ['feature-2', 'a; b; c; d; e', 0.345],
+                                         ['feature-3', 'a; f; g; h', 0.678]],
+                                        columns=['Feature ID', 'Taxon',
+                                                 'Confidence'])
+        self.taxonomy_df.set_index('Feature ID', inplace=True)
+
+        self.table2 = biom.Table(np.array([[0, 1, 2],
+                                           [2, 4, 6],
+                                           [3, 0, 1]]),
+                                 ['feature-1', 'feature-X', 'feature-3'],
+                                 ['sample-1', 'sample-2', 'sample-3'])
+        self.taxonomy2_df = pd.DataFrame([['feature-1', 'a; b; c', 0.123],
+                                          ['feature-X', 'a; b; c; d; e', 0.34],
+                                          ['feature-3', 'a; f; g; h', 0.678]],
+                                         columns=['Feature ID', 'Taxon',
+                                                  'Confidence'])
+
+        self.taxonomy2_df.set_index('Feature ID', inplace=True)
+
+        self.table3 = biom.Table(np.array([[1, 2],
+                                           [0, 1]]),
+                                 ['feature-X', 'feature-3'],
+                                 ['sample-2', 'sample-3'])
+
+        imported_artifact = Artifact.import_data(
+            "FeatureTable[Frequency]", self.table
+        )
+        imported_artifact.save(self.table1_filename)
+        imported_artifact = Artifact.import_data(
+            "FeatureData[Taxonomy]", self.taxonomy_df
+        )
+        imported_artifact.save(self.taxonomy1_filename)
+        imported_artifact = Artifact.import_data(
+            "FeatureTable[Frequency]", self.table2
+        )
+        imported_artifact.save(self.table2_filename)
+        imported_artifact = Artifact.import_data(
+            "FeatureData[Taxonomy]", self.taxonomy2_df
+        )
+        imported_artifact.save(self.taxonomy2_filename)
+        imported_artifact = Artifact.import_data(
+            "FeatureTable[Frequency]", self.table3
+        )
+        imported_artifact.save(self.table3_filename)
+        with biom_open(self.table_biom, 'w') as f:
+            self.table.to_hdf5(f, 'test-table')
+        config.resources.update({'table_resources': {
+            'table1': {
+                'table': self.table1_filename,
+            },
+            'table2': {
+                'table': self.table1_filename,
+                'feature-data-taxonomy': self.taxonomy1_filename,
+            },
+            'table-fish': {
+                'table': self.table_biom,
+                'feature-data-taxonomy': self.taxonomy1_filename,
+                'table-format': 'biom'
+            },
+            'table5': {
+                'table': self.table2_filename,
+            },
+            'table6': {
+                'table': self.table_biom,
+                'table-format': 'biom',
+            },
+        }})
+        resources.update(config.resources)
+
+    def test_resources(self):
+        response = self.client.get(
+            '/api/taxonomy/available')
+
+        self.assertEqual(response.status_code, 200)
+        obs = json.loads(response.data)
+        self.assertIn('resources', obs)
+        self.assertCountEqual(['table2', 'table-fish'], obs['resources'])
+
+    def test_summarize_group(self):
+        response = self.client.post('/api/taxonomy/summarize_group/table2',
+                                    content_type='application/json',
+                                    data=json.dumps({'sample_ids': [
+                                        'sample-1']}))
+
+        print(response.data)
+        self.assertEqual(response.status_code, 200)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['taxonomy', 'features',
+                               'feature_values', 'feature_variances'],
+                              obs.keys())
+
+
+class AlphaIntegrationTests(IntegrationTests):
+
+    def setUp(self):
+        super().setUp()
+        self.series1_filename = self.create_tempfile(suffix='.qza').name
+        self.series2_filename = self.create_tempfile(suffix='.qza').name
+
+        self.series_1 = pd.Series({
+            'sample-foo-bar': 7.24, 'sample-baz-qux': 8.25,
+            'sample-quuz-corge': 6.4, },
+            name='observed_otus'
+        )
+
+        self.series_2 = pd.Series({
+            'sample-foo-bar': 9.01, 'sample-qux-quux': 9.04},
+            name='chao1'
+        )
+
+        imported_artifact = Artifact.import_data(
+            "SampleData[AlphaDiversity]", self.series_1
+        )
+        imported_artifact.save(self.series1_filename)
+        imported_artifact = Artifact.import_data(
+            "SampleData[AlphaDiversity]", self.series_2
+        )
+        imported_artifact.save(self.series2_filename)
+        config.resources.update({'alpha_resources': {
+            'observed_otus': self.series1_filename,
+            'chao1': self.series2_filename,
+        }})
+        resources.update(config.resources)
+
+    def test_resources_available(self):
+        response = self.client.get('/api/diversity/metrics/alpha/available')
+
+        self.assertEqual(response.status_code, 200)
+        obs = json.loads(response.data)
+        self.assertIn('alpha_metrics', obs)
+        self.assertCountEqual(['observed_otus', 'chao1'], obs['alpha_metrics'])
+
+    def test_group_summary(self):
+        response = self.client.post(
+            '/api/diversity/alpha_group/observed_otus'
+            '?summary_statistics=true&percentiles=0,50,100&return_raw=true',
+            content_type='application/json',
+            data=json.dumps({'sample_ids': ['sample-foo-bar',
+                                            'sample-baz-qux']})
+        )
+        self.assertEqual(response.status_code, 200)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['alpha_metric', 'group_summary',
+                               'alpha_diversity'],
+                              obs.keys())
+        self.assertCountEqual(['mean', 'median', 'std', 'group_size',
+                               'percentile', 'percentile_values'],
+                              obs['group_summary'].keys())
+        self.assertListEqual([0, 50, 100],
+                             obs['group_summary']['percentile'])
+        self.assertEqual(3, len(obs['group_summary']['percentile_values']))
+        self.assertDictEqual({'sample-foo-bar': 7.24, 'sample-baz-qux': 8.25},
+                             obs['alpha_diversity'])
+        self.assertEqual('observed_otus', obs['alpha_metric'])
+
+
+class AllIntegrationTest(
+        AlphaIntegrationTests,
+        TaxonomyIntegrationTests,
+        ):
+
+    pass

--- a/microsetta_public_api/config.py
+++ b/microsetta_public_api/config.py
@@ -32,7 +32,5 @@ class ResourcesConfig(dict):
                                      'existing file paths.')
         return True
 
-    pass
-
 
 resources = ResourcesConfig()

--- a/microsetta_public_api/config.py
+++ b/microsetta_public_api/config.py
@@ -9,8 +9,8 @@ class ResourcesConfig(dict):
     def update(self, _m, **kwargs):
 
         for resource_field in self.resource_fields:
-            if resource_field in self:
-                self._validate_resource_locations(self[resource_field])
+            if resource_field in _m:
+                self._validate_resource_locations(_m[resource_field])
 
         return super().update(_m, **kwargs)
 

--- a/microsetta_public_api/repo/_alpha_repo.py
+++ b/microsetta_public_api/repo/_alpha_repo.py
@@ -4,13 +4,14 @@ from microsetta_public_api.resources import resources
 
 class AlphaRepo:
 
-    # resources needs to be a class variable in order to be able to be
-    #  mocked in the test cases
-    resources = dict()
-    resource_locations = None
-
     def __init__(self):
-        self.resources = resources.get('alpha_resources', dict())
+        self._resources = resources.get('alpha_resources', dict())
+
+    # resources needs to be a property in order to be able to be
+    #  mocked in the test cases, but also be instance specific
+    @property
+    def resources(self):
+        return self._resources
 
     def _get_resource(self, metric):
         if metric not in self.available_metrics():

--- a/microsetta_public_api/repo/_taxonomy_repo.py
+++ b/microsetta_public_api/repo/_taxonomy_repo.py
@@ -11,7 +11,7 @@ class TaxonomyRepo:
         def has_taxonomy(_, resource):
             return 'feature-data-taxonomy' in resource and 'table' in resource
 
-        self.tables = dict(filter(has_taxonomy, tables.items()))
+        self.tables = dict(filter(lambda x: has_taxonomy(*x), tables.items()))
 
     def _get_resource(self, name, component=None):
         if name not in self.tables:
@@ -19,7 +19,7 @@ class TaxonomyRepo:
         else:
             res = self.tables[name]
             if component is not None:
-                # should always gibe a table and data for
+                # should always give a table and data for
                 #  'feature-data-taxonomy' and 'table', but may return None
                 #  for 'variances
                 res = res.get(component, None)

--- a/microsetta_public_api/repo/_taxonomy_repo.py
+++ b/microsetta_public_api/repo/_taxonomy_repo.py
@@ -3,15 +3,17 @@ from microsetta_public_api.resources import resources
 
 class TaxonomyRepo:
 
-    tables = None
-
     def __init__(self):
         tables = resources.get('table_resources', dict())
 
         def has_taxonomy(_, resource):
             return 'feature-data-taxonomy' in resource and 'table' in resource
 
-        self.tables = dict(filter(lambda x: has_taxonomy(*x), tables.items()))
+        self._tables = dict(filter(lambda x: has_taxonomy(*x), tables.items()))
+
+    @property
+    def tables(self):
+        return self._tables
 
     def _get_resource(self, name, component=None):
         if name not in self.tables:

--- a/microsetta_public_api/repo/_taxonomy_repo.py
+++ b/microsetta_public_api/repo/_taxonomy_repo.py
@@ -3,8 +3,10 @@ from microsetta_public_api.resources import resources
 
 class TaxonomyRepo:
 
+    tables = None
+
     def __init__(self):
-        tables = resources.get('table_resources')
+        tables = resources.get('table_resources', dict())
 
         def has_taxonomy(_, resource):
             return 'feature-data-taxonomy' in resource and 'table' in resource
@@ -23,7 +25,7 @@ class TaxonomyRepo:
                 res = res.get(component, None)
             return res
 
-    def available_resources(self):
+    def resources(self):
         """Return the tables that have taxonomy information accompanying them
 
         Returns
@@ -34,7 +36,7 @@ class TaxonomyRepo:
         """
         return list(self.tables.keys())
 
-    def table(self, sample_ids, table_name):
+    def table(self, table_name):
         """Obtains subset of a table for a list of samples
 
         Parameters
@@ -46,23 +48,14 @@ class TaxonomyRepo:
             Table to use
 
         """
-        table = self._get_resource(table_name, component='table')
-        return self._filter_table(sample_ids, table)
+        return self._get_resource(table_name, component='table')
 
     def feature_data_taxonomy(self, table_name):
         return self._get_resource(table_name,
                                   component='feature-data-taxonomy')
 
-    def variances(self, sample_ids, table_name):
-        table = self._get_resource(table_name, component='variances')
-        return self._filter_table(sample_ids, table)
-
-    @staticmethod
-    def _filter_table(sample_ids, table):
-        if isinstance(sample_ids, str):
-            return table.filter([sample_ids])
-        else:
-            return table.filter(sample_ids)
+    def variances(self, table_name):
+        return self._get_resource(table_name, component='variances')
 
     def exists(self, sample_ids, table_name):
         """Checks if sample_ids exist for the given table.

--- a/microsetta_public_api/repo/_taxonomy_repo.py
+++ b/microsetta_public_api/repo/_taxonomy_repo.py
@@ -1,2 +1,93 @@
+from microsetta_public_api.resources import resources
+
+
 class TaxonomyRepo:
-    pass
+
+    def __init__(self):
+        tables = resources.get('table_resources')
+
+        def has_taxonomy(_, resource):
+            return 'feature-data-taxonomy' in resource and 'table' in resource
+
+        self.tables = dict(filter(has_taxonomy, tables.items()))
+
+    def _get_resource(self, name, component=None):
+        if name not in self.tables:
+            raise ValueError(f'No table with taxonomy available for `{name}`')
+        else:
+            res = self.tables[name]
+            if component is not None:
+                # should always gibe a table and data for
+                #  'feature-data-taxonomy' and 'table', but may return None
+                #  for 'variances
+                res = res.get(component, None)
+            return res
+
+    def available_resources(self):
+        """Return the tables that have taxonomy information accompanying them
+
+        Returns
+        -------
+        list of str:
+            Names of tables that this repo has configured with taxonomy
+
+        """
+        return list(self.tables.keys())
+
+    def table(self, sample_ids, table_name):
+        """Obtains subset of a table for a list of samples
+
+        Parameters
+        ----------
+        sample_ids : str or list of str
+            Ids for which to obtain taxonomy group.
+
+        table_name : str
+            Table to use
+
+        """
+        table = self._get_resource(table_name, component='table')
+        return self._filter_table(sample_ids, table)
+
+    def feature_data_taxonomy(self, table_name):
+        return self._get_resource(table_name,
+                                  component='feature-data-taxonomy')
+
+    def variances(self, sample_ids, table_name):
+        table = self._get_resource(table_name, component='variances')
+        return self._filter_table(sample_ids, table)
+
+    @staticmethod
+    def _filter_table(sample_ids, table):
+        if isinstance(sample_ids, str):
+            return table.filter([sample_ids])
+        else:
+            return table.filter(sample_ids)
+
+    def exists(self, sample_ids, table_name):
+        """Checks if sample_ids exist for the given table.
+
+        Parameters
+        ----------
+        sample_ids : str or list of str
+            Ids for to check database for.
+
+        table_name : str
+            Table to check
+
+        Returns
+        -------
+        bool or list of bool
+            If sample_ids is str, then this returns a bool corresponding to
+            whether the given sample ID exists. If given a list, each entry
+            `i` corresponds to whether `sample_ids[i]` exists
+            in the database.
+
+        """
+        table_resource = self._get_resource(table_name)
+        if isinstance(sample_ids, str):
+            # table_resource['table'] will be a biom table
+            return sample_ids in table_resource['table'].ids()
+        else:
+            existing_ids = set(table_resource['table'].ids())
+            return [(id_ in existing_ids) for id_ in sample_ids]

--- a/microsetta_public_api/repo/_taxonomy_repo.py
+++ b/microsetta_public_api/repo/_taxonomy_repo.py
@@ -1,0 +1,2 @@
+class TaxonomyRepo:
+    pass

--- a/microsetta_public_api/repo/tests/test_alpha_repo.py
+++ b/microsetta_public_api/repo/tests/test_alpha_repo.py
@@ -45,6 +45,7 @@ class TestAlphaRepoWithResources(TempfileTestCase):
             "SampleData[AlphaDiversity]", test_series2
         )
         imported_artifact.save(resource_filename2)
+        config.resources.clear()
         config.resources.update({
             'alpha_resources': {
                 'chao1': resource_filename1,

--- a/microsetta_public_api/repo/tests/test_alpha_repo.py
+++ b/microsetta_public_api/repo/tests/test_alpha_repo.py
@@ -6,7 +6,8 @@ from pandas.testing import assert_series_equal
 
 from microsetta_public_api import config
 from microsetta_public_api.resources import resources
-from microsetta_public_api.utils.testing import TempfileTestCase
+from microsetta_public_api.utils.testing import (TempfileTestCase,
+                                                 ConfigTestCase)
 from microsetta_public_api.repo._alpha_repo import AlphaRepo
 from microsetta_public_api.exceptions import UnknownMetric
 
@@ -24,12 +25,11 @@ class TestAlphaRepoHelpers(TempfileTestCase):
                 alpha_repo._get_resource('fake-test-metric')
 
 
-class TestAlphaRepoWithResources(TempfileTestCase):
+class TestAlphaRepoWithResources(TempfileTestCase, ConfigTestCase):
 
     def setUp(self):
-        super().setUp()
-        self._config_copy = config.resources.copy()
-        self._resources_copy = resources.copy()
+        ConfigTestCase.setUp(self)
+        TempfileTestCase.setUp(self)
         self.no_resources_repo = AlphaRepo()
         resource_filename1 = self.create_tempfile(suffix='.qza').name
         resource_filename2 = self.create_tempfile(suffix='.qza').name
@@ -59,10 +59,8 @@ class TestAlphaRepoWithResources(TempfileTestCase):
         self.repo = AlphaRepo()
 
     def tearDown(self):
-        config.resources = self._config_copy
-        resources.clear()
-        resources.update(self._resources_copy)
-        super().tearDown()
+        TempfileTestCase.tearDown(self)
+        ConfigTestCase.tearDown(self)
 
     def test_available_metrics(self):
         exp = ['chao1', 'faith_pd']

--- a/microsetta_public_api/repo/tests/test_alpha_repo.py
+++ b/microsetta_public_api/repo/tests/test_alpha_repo.py
@@ -27,6 +27,9 @@ class TestAlphaRepoHelpers(TempfileTestCase):
 class TestAlphaRepoWithResources(TempfileTestCase):
 
     def setUp(self):
+        super().setUp()
+        self._config_copy = config.resources.copy()
+        self._resources_copy = resources.copy()
         self.no_resources_repo = AlphaRepo()
         resource_filename1 = self.create_tempfile(suffix='.qza').name
         resource_filename2 = self.create_tempfile(suffix='.qza').name
@@ -45,7 +48,6 @@ class TestAlphaRepoWithResources(TempfileTestCase):
             "SampleData[AlphaDiversity]", test_series2
         )
         imported_artifact.save(resource_filename2)
-        config.resources.clear()
         config.resources.update({
             'alpha_resources': {
                 'chao1': resource_filename1,
@@ -55,6 +57,12 @@ class TestAlphaRepoWithResources(TempfileTestCase):
         resources.update(config.resources)
 
         self.repo = AlphaRepo()
+
+    def tearDown(self):
+        config.resources = self._config_copy
+        resources.clear()
+        resources.update(self._resources_copy)
+        super().tearDown()
 
     def test_available_metrics(self):
         exp = ['chao1', 'faith_pd']

--- a/microsetta_public_api/repo/tests/test_taxonomy_repo.py
+++ b/microsetta_public_api/repo/tests/test_taxonomy_repo.py
@@ -43,7 +43,7 @@ class TestTaxonomyRepoWithResources(TempfileTestCase):
     def setUp(self):
         self._config_copy = config.resources.copy()
         self._resources_copy = resources.copy()
-        self._no_resources_repo = TaxonomyRepo()
+        self.no_resources_repo = TaxonomyRepo()
         self.table1_filename = self.create_tempfile(suffix='.qza').name
         self.taxonomy1_filename = self.create_tempfile(suffix='.qza').name
         self.table2_filename = self.create_tempfile(suffix='.qza').name
@@ -143,6 +143,11 @@ class TestTaxonomyRepoWithResources(TempfileTestCase):
     def test_available_taxonomy_tables(self):
         exp = ['table2', 'table3', 'table4']
         obs = self.repo.resources()
+        self.assertCountEqual(exp, obs)
+
+    def test_available_taxonomy_tables_empty_repo(self):
+        exp = []
+        obs = self.no_resources_repo.resources()
         self.assertCountEqual(exp, obs)
 
     def test_get_table(self):

--- a/microsetta_public_api/repo/tests/test_taxonomy_repo.py
+++ b/microsetta_public_api/repo/tests/test_taxonomy_repo.py
@@ -1,0 +1,188 @@
+from unittest import TestCase
+from unittest.mock import patch, PropertyMock
+import pandas as pd
+import numpy as np
+import biom
+from biom.util import biom_open
+from qiime2 import Artifact
+from pandas.testing import assert_frame_equal
+
+from microsetta_public_api import config
+from microsetta_public_api.resources import resources
+from microsetta_public_api.utils.testing import TempfileTestCase
+from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
+
+
+class TestTaxonomyRepoHelpers(TestCase):
+
+    def test_get_resource_table_not_available(self):
+        taxonomy_repo = TaxonomyRepo()
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo'
+                   '.tables', new_callable=PropertyMock) as mock_tables:
+            mock_tables.return_value = {'foo': {'table': 'some-tb'},
+                                        'bar': {'table': 'some-other-tb'}}
+            with self.assertRaisesRegex(ValueError, 'No table with taxonomy '
+                                                    'available for '
+                                                    '`bad-table`'):
+                taxonomy_repo._get_resource('bad-table')
+
+    def test_get_resource_component(self):
+        taxonomy_repo = TaxonomyRepo()
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo'
+                   '.tables', new_callable=PropertyMock) as mock_tables:
+            mock_tables.return_value = {'foo': {'table': 'some-tb',
+                                                'variances': 'var-tb'},
+                                        'bar': {'table': 'some-other-tb'}}
+
+            res = taxonomy_repo._get_resource('bar')
+        self.assertDictEqual({'table': 'some-other-tb'}, res)
+
+
+class TestTaxonomyRepoWithResources(TempfileTestCase):
+
+    def setUp(self):
+        self._config_copy = config.resources.copy()
+        self._resources_copy = resources.copy()
+        self._no_resources_repo = TaxonomyRepo()
+        self.table1_filename = self.create_tempfile(suffix='.qza').name
+        self.taxonomy1_filename = self.create_tempfile(suffix='.qza').name
+        self.table2_filename = self.create_tempfile(suffix='.qza').name
+        self.taxonomy2_filename = self.create_tempfile(suffix='.qza').name
+        self.table3_filename = self.create_tempfile(suffix='.qza').name
+        self.var_table_filename = self.create_tempfile(suffix='.qza').name
+        self.table_biom = self.create_tempfile(suffix='.biom').name
+
+        self.table = biom.Table(np.array([[0, 1, 2],
+                                          [2, 4, 6],
+                                          [3, 0, 1]]),
+                                ['feature-1', 'feature-2', 'feature-3'],
+                                ['sample-1', 'sample-2', 'sample-3'])
+
+        self.taxonomy_df = pd.DataFrame([['feature-1', 'a; b; c', 0.123],
+                                         ['feature-2', 'a; b; c; d; e', 0.345],
+                                         ['feature-3', 'a; f; g; h', 0.678]],
+                                        columns=['Feature ID', 'Taxon',
+                                                 'Confidence'])
+        self.taxonomy_df.set_index('Feature ID', inplace=True)
+
+        self.table2 = biom.Table(np.array([[0, 1, 2],
+                                           [2, 4, 6],
+                                           [3, 0, 1]]),
+                                 ['feature-1', 'feature-X', 'feature-3'],
+                                 ['sample-1', 'sample-2', 'sample-3'])
+        self.taxonomy2_df = pd.DataFrame([['feature-1', 'a; b; c', 0.123],
+                                          ['feature-X', 'a; b; c; d; e', 0.34],
+                                          ['feature-3', 'a; f; g; h', 0.678]],
+                                         columns=['Feature ID', 'Taxon',
+                                                  'Confidence'])
+
+        self.taxonomy2_df.set_index('Feature ID', inplace=True)
+
+        self.table3 = biom.Table(np.array([[1, 2],
+                                           [0, 1]]),
+                                 ['feature-X', 'feature-3'],
+                                 ['sample-2', 'sample-3'])
+
+        imported_artifact = Artifact.import_data(
+            "FeatureTable[Frequency]", self.table
+        )
+        imported_artifact.save(self.table1_filename)
+        imported_artifact = Artifact.import_data(
+            "FeatureData[Taxonomy]", self.taxonomy_df
+        )
+        imported_artifact.save(self.taxonomy1_filename)
+        imported_artifact = Artifact.import_data(
+            "FeatureTable[Frequency]", self.table2
+        )
+        imported_artifact.save(self.table2_filename)
+        imported_artifact = Artifact.import_data(
+            "FeatureData[Taxonomy]", self.taxonomy2_df
+        )
+        imported_artifact.save(self.taxonomy2_filename)
+        imported_artifact = Artifact.import_data(
+            "FeatureTable[Frequency]", self.table3
+        )
+        imported_artifact.save(self.table3_filename)
+        with biom_open(self.table_biom, 'w') as f:
+            self.table.to_hdf5(f, 'test-table')
+        config.resources.update({'table_resources': {
+            'table1': {
+                'table': self.table1_filename,
+            },
+            'table2': {
+                'table': self.table1_filename,
+                'feature-data-taxonomy': self.taxonomy1_filename,
+            },
+            'table3': {
+                'table': self.table3_filename,
+                'feature-data-taxonomy': self.taxonomy2_filename,
+                'variances': self.table3_filename,
+            },
+            'table4': {
+                'table': self.table_biom,
+                'feature-data-taxonomy': self.taxonomy1_filename,
+                'table-format': 'biom'
+            },
+            'table5': {
+                'table': self.table2_filename,
+            },
+            'table6': {
+                'table': self.table_biom,
+                'table-format': 'biom',
+            },
+        }})
+        resources.update(config.resources)
+        self.repo = TaxonomyRepo()
+
+    def tearDown(self):
+        config.resources = self._config_copy
+        resources.clear()
+        resources.update(self._resources_copy)
+        super().tearDown()
+
+    def test_available_taxonomy_tables(self):
+        exp = ['table2', 'table3', 'table4']
+        obs = self.repo.resources()
+        self.assertCountEqual(exp, obs)
+
+    def test_get_table(self):
+        exp = self.table
+        obs = self.repo.table('table2')
+        self.assertEqual(exp, obs)
+
+    def test_get_table_invalid(self):
+        with self.assertRaises(ValueError):
+            self.repo.table('table1')
+
+    def test_get_taxonomy(self):
+        exp = self.taxonomy_df
+        obs = self.repo.feature_data_taxonomy('table4')
+        obs['Confidence'] = obs['Confidence'].astype('float64')
+        assert_frame_equal(exp, obs)
+
+    def test_get_taxonomy_invalid(self):
+        with self.assertRaises(ValueError):
+            self.repo.table('foo')
+
+    def test_get_variances(self):
+        exp = self.table3
+        obs = self.repo.variances('table3')
+        self.assertEqual(exp, obs)
+
+    def test_get_variances_none(self):
+        exp = None
+        obs = self.repo.variances('table4')
+        self.assertIs(exp, obs)
+
+    def test_get_variances_invalid(self):
+        with self.assertRaises(ValueError):
+            self.repo.table('table6')
+
+    def test_exists(self):
+        exp = [False, True, True]
+        obs = self.repo.exists(['sample-1', 'sample-2', 'sample-3'], 'table3')
+        self.assertListEqual(exp, obs)
+
+    def test_exists_single(self):
+        obs = self.repo.exists('sample-1', 'table2')
+        self.assertTrue(obs)

--- a/microsetta_public_api/repo/tests/test_taxonomy_repo.py
+++ b/microsetta_public_api/repo/tests/test_taxonomy_repo.py
@@ -9,7 +9,8 @@ from pandas.testing import assert_frame_equal
 
 from microsetta_public_api import config
 from microsetta_public_api.resources import resources
-from microsetta_public_api.utils.testing import TempfileTestCase
+from microsetta_public_api.utils.testing import (TempfileTestCase,
+                                                 ConfigTestCase)
 from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
 
 
@@ -38,11 +39,11 @@ class TestTaxonomyRepoHelpers(TestCase):
         self.assertDictEqual({'table': 'some-other-tb'}, res)
 
 
-class TestTaxonomyRepoWithResources(TempfileTestCase):
+class TestTaxonomyRepoWithResources(TempfileTestCase, ConfigTestCase):
 
     def setUp(self):
-        self._config_copy = config.resources.copy()
-        self._resources_copy = resources.copy()
+        TempfileTestCase.setUp(self)
+        ConfigTestCase.setUp(self)
         self.no_resources_repo = TaxonomyRepo()
         self.table1_filename = self.create_tempfile(suffix='.qza').name
         self.taxonomy1_filename = self.create_tempfile(suffix='.qza').name
@@ -135,10 +136,8 @@ class TestTaxonomyRepoWithResources(TempfileTestCase):
         self.repo = TaxonomyRepo()
 
     def tearDown(self):
-        config.resources = self._config_copy
-        resources.clear()
-        resources.update(self._resources_copy)
-        super().tearDown()
+        TempfileTestCase.tearDown(self)
+        ConfigTestCase.tearDown(self)
 
     def test_available_taxonomy_tables(self):
         exp = ['table2', 'table3', 'table4']

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -1,22 +1,134 @@
 import os
 import pandas as pd
+import biom
 from copy import deepcopy
 from microsetta_public_api.exceptions import ConfigurationError
 from qiime2 import Artifact
 from q2_types.sample_data import AlphaDiversity, SampleData
+from q2_types.feature_table import FeatureTable, Frequency
+from q2_types.feature_data import FeatureData, Taxonomy
+
+
+def _dict_of_paths_to_alpha_data(dict_of_qza_paths, resource_name):
+    _validate_dict_of_qza_paths(dict_of_qza_paths,
+                                resource_name)
+    new_resource = _replace_paths_with_qza(dict_of_qza_paths,
+                                           SampleData[AlphaDiversity],
+                                           view_type=pd.Series)
+    return new_resource
+
+
+def _transform_dict_of_table(dict_, resource_name):
+    if not isinstance(dict_, dict):
+        raise TypeError(f"Expected field '{resource_name}' to contain a "
+                        f"dictionary. Got {dict_}.")
+    new_resource = dict()
+    for table_name, attributes in dict_.items():
+        res = _transform_single_table(attributes, table_name)
+        new_resource[table_name] = res
+    return new_resource
+
+
+def _transform_single_table(dict_, resource_name):
+    _validate_dict_of_qza_paths(dict_, resource_name, allow_none=True,
+                                required_fields=['table'],
+                                non_qza_entries=['table-type'],
+                                allow_extras=True,
+                                )
+    semantic_types = {
+        'table': dict_.get('table-type', FeatureTable[Frequency]),
+        'feature-data-taxonomy': FeatureData[Taxonomy],
+        'variances': FeatureTable[Frequency],
+    }
+    views = {
+        'table': biom.Table,
+        'feature-data-taxonomy': pd.DataFrame,
+        'variances': biom.Table,
+    }
+    new_resource = deepcopy(dict_)
+    for key, value in dict_.items():
+        if key in semantic_types:
+            new_resource[key] = _parse_q2_data(value,
+                                               semantic_types[key],
+                                               view_type=views.get(key, None),
+                                               )
+    return new_resource
+
+
+def _parse_q2_data(filepath, semantic_type, view_type=None):
+    try:
+        data = Artifact.load(filepath)
+    except ValueError as e:
+        raise ConfigurationError(*e.args)
+
+    if data.type != semantic_type:
+        raise ConfigurationError(f"Expected QZA '{filepath}' to have type "
+                                 f"'{semantic_type}'. "
+                                 f"Received '{data.type}'.")
+    if view_type is not None:
+        data = data.view(view_type=view_type)
+
+    return data
+
+
+def _validate_dict_of_qza_paths(dict_of_qza_paths, name, allow_none=False,
+                                required_fields=None, allow_extras=False,
+                                non_qza_entries=None,
+                                ):
+    if non_qza_entries is None:
+        non_qza_entries = []
+    if not isinstance(dict_of_qza_paths, dict):
+        raise ValueError(f"Expected '{name}' field to contain a dict. "
+                         f"Got {type(dict_of_qza_paths).__name__}")
+    if required_fields:
+        for field in required_fields:
+            if field not in dict_of_qza_paths:
+                raise ValueError(f"Did not get required field '{field}'.")
+        if not allow_extras:
+            allowed_keys = set(required_fields) | set(non_qza_entries)
+            extra_keys = list(filter(lambda x: x not in allowed_keys,
+                                     dict_of_qza_paths.keys()))
+            if extra_keys:
+                raise ValueError(f"Extra keys: {extra_keys} not allowed.")
+
+    for key, value in dict_of_qza_paths.items():
+        if key in non_qza_entries:
+            continue
+        is_qza = isinstance(value, str) and (value.endswith('.qza'))
+        exists = isinstance(value, str) and os.path.exists(value)
+        is_none = value is None
+        value_is_existing_qza_path = (is_qza and exists) or \
+                                     (is_none and allow_none)
+
+        if not value_is_existing_qza_path:
+            raise ValueError('Expected existing path with .qza '
+                             'extension. Got: {}'.format(value))
+
+
+def _replace_paths_with_qza(dict_of_qza_paths, semantic_type, view_type=None):
+    new_resource = dict()
+    for key, value in dict_of_qza_paths.items():
+        new_resource[key] = _parse_q2_data(value,
+                                           semantic_type,
+                                           view_type=view_type,
+                                           )
+    return new_resource
 
 
 class ResourceManager(dict):
 
-    dict_of_qza_resources = {'alpha_resources': SampleData[AlphaDiversity]}
+    transformers = {
+        'alpha_resources': _dict_of_paths_to_alpha_data,
+        'table_resources': _transform_dict_of_table,
+    }
 
-    def update(self, other, **kwargs):
+    def update(self, *args, **kwargs):
         """
         Updates the managers resources.
 
         Parameters
         ----------
-        other : dict
+        other : optional dict
             Resource identifier to resource mapping. 'alpha_resources' is
             reserved for a dictionary. The values in 'alpha_resources' must be
             existing file paths with a .qza extension, they will be read
@@ -31,53 +143,46 @@ class ResourceManager(dict):
 
         Examples
         --------
-        >>> resources = ResourceManager(alpha_resources={
-        ...     {'faith_pd': '/path/to/some.qza',
-        ...      'chao1': '/another/path/to/a.qza',
-        ...     }}, some_other_resource='here is a string resource')
-
+        >>> resources = ResourceManager(
+        ...     alpha_resources={
+        ...         'faith_pd': '/path/to/some.qza',
+        ...         'chao1': '/another/path/to/a.qza',
+        ...     },
+        ...     table_resources={
+        ...         'greengenes_13.8_insertion': {
+        ...             'table': '/path/to/feature-table.qza',
+        ...             'feature-data-taxonomy': '/a/feat-data-taxonomy.qza',
+        ...             'variances': '/a/variance/feature-table.qza',
+        ...         },
+        ...         'some_other_feature_table': {
+        ...             'table': '/another/path/tofeature-table.qza',
+        ...             'variances': '/a/variance/feature-table.qza',
+        ...             'table-type': FeatureTable[Frequency],
+        ...         },
+        ...     }
+        ...     some_other_resource='here is a string resource',
+        ...     )
 
         """
-        for resource_name, type_ in self.dict_of_qza_resources.items():
+        if len(args) == 1 and isinstance(args[0], dict):
+            other = args[0]
+        elif len(args) == 0:
+            other = dict()
+        else:
+            raise TypeError(f'update expected at most 1 positional argument '
+                            f'that is a dict. Got {args}')
+
+        for resource_name, transformer in self.transformers.items():
             if resource_name in other:
-                other = self._replace_paths_with_qza(other, resource_name,
-                                                     type_)
+                new_resource = transformer(other[resource_name],
+                                           resource_name)
+                other.update({resource_name: new_resource})
             if resource_name in kwargs:
-                kwargs = self._replace_paths_with_qza(kwargs, resource_name,
-                                                      type_)
+                new_resource = transformer(kwargs[resource_name],
+                                           resource_name)
+                kwargs.update({resource_name: new_resource})
 
         return super().update(other, **kwargs)
-
-    def _replace_paths_with_qza(self, resource, name, semantic_type):
-        dict_of_qza_paths = resource[name]
-        if not isinstance(dict_of_qza_paths, dict):
-            raise ValueError(f"Expected '{name}' field to contain a dict. "
-                             f"Got {type(resource[name]).__name__}")
-        new_resource = deepcopy(resource)
-        for key, value in dict_of_qza_paths.items():
-            value_is_existing_qza_path = isinstance(value, str) and \
-                (value[-4:] == '.qza') and os.path.exists(value)
-            if value_is_existing_qza_path:
-                new_resource[name][key] = self._parse_q2_data(value,
-                                                              semantic_type)
-            else:
-                raise ValueError(f'Expected existing path with .qza '
-                                 f'extension. Got: {value}')
-        return new_resource
-
-    @staticmethod
-    def _parse_q2_data(filepath, semantic_type):
-        try:
-            data = Artifact.load(filepath)
-        except ValueError as e:
-            raise ConfigurationError(*e.args)
-
-        if data.type != semantic_type:
-            raise ConfigurationError(f"Expected QZA '{filepath}' to have type "
-                                     f"'{semantic_type}'. "
-                                     f"Received '{data.type}'.")
-
-        return data.view(pd.Series)
 
 
 resources = ResourceManager()

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -199,6 +199,7 @@ class ResourceManager(dict):
         ...     )
 
         """
+        to_add = dict()
         if len(args) == 1 and isinstance(args[0], dict):
             other = args[0]
         elif len(args) == 0:
@@ -207,17 +208,19 @@ class ResourceManager(dict):
             raise TypeError(f'update expected at most 1 positional argument '
                             f'that is a dict. Got {args}')
 
+        to_add.update(other, **kwargs)
+
         for resource_name, transformer in self.transformers.items():
             if resource_name in other:
                 new_resource = transformer(other[resource_name],
                                            resource_name)
-                other.update({resource_name: new_resource})
+                to_add.update({resource_name: new_resource})
             if resource_name in kwargs:
                 new_resource = transformer(kwargs[resource_name],
                                            resource_name)
-                kwargs.update({resource_name: new_resource})
+                to_add.update({resource_name: new_resource})
 
-        return super().update(other, **kwargs)
+        return dict.update(self, to_add, **kwargs)
 
 
 resources = ResourceManager()

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -1,52 +1,74 @@
 import pandas as pd
-from pandas.util.testing import assert_series_equal
+import numpy as np
+import biom
+from pandas.util.testing import assert_series_equal, assert_frame_equal
 from qiime2 import Artifact
 from q2_types.sample_data import SampleData, AlphaDiversity
+from q2_types.feature_table import FeatureTable, Frequency
 
 from microsetta_public_api.exceptions import ConfigurationError
 from microsetta_public_api.utils.testing import TempfileTestCase
-from microsetta_public_api.resources import ResourceManager
+from microsetta_public_api.resources import ResourceManager, _parse_q2_data
 
 
-class TestResourceManager(TempfileTestCase):
+class TestResourceManagerUpdateAlpha(TempfileTestCase):
 
-    def test_update(self):
-        resources = ResourceManager(some_key='some_value')
+    def setUp(self):
+        super().setUp()
+        self.qza_resource_fp = self.create_tempfile(suffix='.qza').name
+        self.qza_resource_fp2 = self.create_tempfile(suffix='.qza').name
+        self.qza_resource_fh2 = self.create_tempfile(suffix='.qza')
+        self.qza_resource_fh2.close()
+        self.qza_resource_dne = self.qza_resource_fh2.name
+        self.non_qza_resource_fp = self.create_tempfile(
+            suffix='.some_ext').name
+        self.test_series = pd.Series({'sample1': 7.15, 'sample2': 9.04},
+                                     name='chao1')
+        self.test_series2 = pd.Series({'sample1': 7.16, 'sample2': 9.01},
+                                      name='faith_pd')
+        self.resources = ResourceManager(some_key='some_value')
 
-        qza_resource_fp = self.create_tempfile(suffix='.qza').name
-        qza_resource_fp2 = self.create_tempfile(suffix='.qza').name
-        test_series = pd.Series({'sample1': 7.15, 'sample2': 9.04},
-                                name='chao1')
-        test_series2 = pd.Series({'sample1': 7.16, 'sample2': 9.01},
-                                 name='faith_pd')
         imported_artifact = Artifact.import_data(
-            "SampleData[AlphaDiversity]", test_series
+            "SampleData[AlphaDiversity]", self.test_series
         )
-        imported_artifact.save(qza_resource_fp)
+        imported_artifact.save(self.qza_resource_fp)
+        self.update_with = {'random-value': 7.24,
+                            'alpha_resources': {'chao1': self.qza_resource_fp,
+                                                'faith_pd': 9,
+                                                },
+                            'other': {'dict': {'of': 'things'}},
+                            }
+
+    def test_update_alpha_resources(self):
+
         imported_artifact = Artifact.import_data(
-            "SampleData[AlphaDiversity]", test_series2
+            "SampleData[AlphaDiversity]", self.test_series
         )
-        imported_artifact.save(qza_resource_fp2)
+        imported_artifact.save(self.qza_resource_fp)
+        imported_artifact = Artifact.import_data(
+            "SampleData[AlphaDiversity]", self.test_series2
+        )
+        imported_artifact.save(self.qza_resource_fp2)
 
         update_with = {'random-value': 7.24,
-                       'alpha_resources': {'chao1': qza_resource_fp,
-                                           'faith_pd': qza_resource_fp2,
+                       'alpha_resources': {'chao1': self.qza_resource_fp,
+                                           'faith_pd': self.qza_resource_fp2,
                                            },
                        'other': {'dict': {'of': 'things'}},
                        }
-        resources.update(update_with)
+        self.resources.update(update_with)
 
         exp = {'some_key': 'some_value',
                'random-value': 7.24,
                'other': {'dict': {'of': 'things'}},
                }
 
-        exp_alpha_resources = {'chao1': test_series,
-                               'faith_pd': test_series2,
+        exp_alpha_resources = {'chao1': self.test_series,
+                               'faith_pd': self.test_series2,
                                }
-        self.assertIn('alpha_resources', resources)
-        obs_alpha_resources = resources.pop('alpha_resources')
-        self.assertDictEqual(resources, exp)
+        self.assertIn('alpha_resources', self.resources)
+        obs_alpha_resources = self.resources.pop('alpha_resources')
+        self.assertDictEqual(self.resources, exp)
         self.assertListEqual(list(obs_alpha_resources.keys()),
                              ['chao1', 'faith_pd'])
         assert_series_equal(obs_alpha_resources['chao1'],
@@ -54,45 +76,212 @@ class TestResourceManager(TempfileTestCase):
         assert_series_equal(obs_alpha_resources['faith_pd'],
                             exp_alpha_resources['faith_pd'])
 
-    def test_update_bad_alpha_resources(self):
-        resources = ResourceManager(some_key='some_value')
-
-        qza_resource_fp = self.create_tempfile(suffix='.qza').name
-        qza_resource_fh2 = self.create_tempfile(suffix='.qza')
-        qza_resource_fp2 = qza_resource_fh2.name
-        qza_resource_fh2.close()
-        non_qza_resource_fp = self.create_tempfile(suffix='.some_ext').name
-        test_series = pd.Series({'sample1': 7.15, 'sample2': 9.04},
-                                name='chao1')
-        imported_artifact = Artifact.import_data(
-            "SampleData[AlphaDiversity]", test_series
-        )
-        imported_artifact.save(qza_resource_fp)
-        update_with = {'random-value': 7.24,
-                       'alpha_resources': {'chao1': qza_resource_fp,
-                                           'faith_pd': 9,
-                                           },
-                       'other': {'dict': {'of': 'things'}},
-                       }
+    def test_update_alpha_resources_qza_dne(self):
         with self.assertRaisesRegex(ValueError,
                                     'Expected existing path with .qza'):
-            resources.update(update_with)
+            self.resources.update(self.update_with)
 
         with self.assertRaisesRegex(ValueError,
                                     'Expected existing path with .qza'):
-            update_with['alpha_resources']['faith_pd'] = qza_resource_fp2
-            resources.update(update_with)
+            self.update_with['alpha_resources']['faith_pd'] = \
+                self.qza_resource_dne
+            self.resources.update(self.update_with)
 
         with self.assertRaisesRegex(ValueError,
                                     'Expected existing path with .qza'):
-            update_with['alpha_resources']['faith_pd'] = non_qza_resource_fp
-            resources.update(update_with)
+            self.update_with['faith_pd'] = self.qza_resource_dne
+            self.resources.update(alpha_resources=self.update_with)
+
+    def test_update_alpha_resources_path_is_not_qza(self):
+
+        with self.assertRaisesRegex(ValueError,
+                                    'Expected existing path with .qza'):
+            self.update_with['alpha_resources']['faith_pd'] = \
+                self.non_qza_resource_fp
+            self.resources.update(self.update_with)
+
+        with self.assertRaisesRegex(ValueError,
+                                    'Expected existing path with .qza'):
+            self.update_with['faith_pd'] = self.non_qza_resource_fp
+            self.resources.update(alpha_resources=self.update_with)
+
+    def test_update_alpha_resources_non_dict(self):
+        with self.assertRaisesRegex(ValueError,
+                                    "Expected 'alpha_resources' field to "
+                                    "contain a dict. Got int"):
+            self.update_with['alpha_resources'] = 9
+            self.resources.update(self.update_with)
 
         with self.assertRaisesRegex(ValueError,
                                     "Expected 'alpha_resources' field to "
                                     "contain a dict. Got int"):
-            update_with['alpha_resources'] = 9
-            resources.update(update_with)
+            update_with = 9
+            self.resources.update(alpha_resources=update_with)
+
+
+class TestResourceManagerUpdateTables(TempfileTestCase):
+    def setUp(self):
+        super().setUp()
+        self.table = biom.Table(np.array([[0, 1, 2],
+                                          [2, 4, 6],
+                                          [3, 0, 1]]),
+                                ['feature-1', 'feature-2', 'feature-3'],
+                                ['sample-1', 'sample-2', 'sample-3'])
+        self.taxonomy_df = pd.DataFrame([['feature-1', 'a; b; c', 0.123],
+                                         ['feature-2', 'a; b; c; d; e', 0.345],
+                                         ['feature-3', 'a; f; g; h', 0.678]],
+                                        columns=['Feature ID', 'Taxon',
+                                                 'Confidence'])
+        self.taxonomy_df.set_index('Feature ID', inplace=True)
+        self.table2 = biom.Table([[0, 0.1, 0.2],
+                                  [0.2, 0.4, 0.6],
+                                  [0.3, 0, 0.1]],
+                                 ['feature-1', 'feature-2', 'feature-3'],
+                                 ['sample-1', 'sample-2', 'sample-3'])
+
+        self.table_artifact = Artifact.import_data(
+            "FeatureTable[Frequency]", self.table
+        )
+        self.taxonomy_artifact = Artifact.import_data(
+            "FeatureData[Taxonomy]", self.taxonomy_df,
+        )
+        self.table2_artifact = Artifact.import_data(
+            "FeatureTable[Frequency]", self.table2
+        )
+        self.table_qza = self.create_tempfile(suffix='.qza').name
+        self.table_artifact.save(self.table_qza)
+        self.taxonomy_qza = self.create_tempfile(suffix='.qza').name
+        self.taxonomy_artifact.save(self.taxonomy_qza)
+        self.table2_qza = self.create_tempfile(suffix='.qza').name
+        self.table2_artifact.save(self.table2_qza)
+        self.resources = ResourceManager()
+        self.config = {'table_resources': {
+            'simple-table': {
+                'table': self.table_qza,
+                'table-type': FeatureTable[Frequency]
+            },
+            'second-simple-table': {
+                'table': self.table2_qza,
+            },
+            'table-with-taxonomy': {
+                'table': self.table_qza,
+                'feature-data-taxonomy': self.taxonomy_qza,
+            },
+            'table-with-variance': {
+                'table': self.table_qza,
+                'variances': self.table2_qza,
+            },
+            'table-with-taxonomy-and-variance': {
+                'table': self.table_qza,
+                'feature-data-taxonomy': self.taxonomy_qza,
+                'variances': self.table2_qza,
+            },
+        }}
+
+    def test_simple_table(self):
+        subset_table = 'simple-table'
+        config = {'table_resources': {
+            subset_table: self.config['table_resources'][subset_table]}}
+        self.resources.update(config)
+        self.assertListEqual(list(self.resources['table_resources']),
+                             ['simple-table'])
+        new_table_config = self.resources['table_resources']['simple-table']
+        self.assertIn('table',
+                      new_table_config)
+        exp_table = self.table
+        obs_table = new_table_config['table']
+
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
+
+    def test_two_tables(self):
+        config = {'table_resources': {
+            'table1': self.config['table_resources']['simple-table'],
+            'table2': self.config['table_resources']['second-simple-table'],
+        }}
+        self.resources.update(config)
+        new_table_config = self.resources['table_resources']
+        self.assertCountEqual(list(self.resources['table_resources']),
+                              ['table1', 'table2'])
+        exp_table = self.table
+        obs_table = new_table_config['table1']['table']
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
+        exp_table = self.table2
+        obs_table = new_table_config['table2']['table']
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
+
+    def test_table_with_taxonomy(self):
+        subset_table = 'table-with-taxonomy'
+        config = {'table_resources': {
+            subset_table: self.config['table_resources'][subset_table]}}
+        self.resources.update(config)
+        self.assertListEqual(list(self.resources['table_resources']),
+                             [subset_table])
+        new_table_config = self.resources['table_resources'][
+            subset_table]
+        self.assertCountEqual(['table', 'feature-data-taxonomy'],
+                              new_table_config.keys())
+
+        exp_table = self.table
+        obs_table = new_table_config['table']
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
+
+        exp_tax = self.taxonomy_df
+        obs_tax = new_table_config['feature-data-taxonomy']
+        obs_tax['Confidence'] = obs_tax['Confidence'].astype('float')
+        assert_frame_equal(exp_tax, obs_tax)
+
+    def test_table_with_variance(self):
+        subset_table = 'table-with-variance'
+        config = {'table_resources': {
+            subset_table: self.config['table_resources'][subset_table]}}
+        self.resources.update(config)
+        self.assertListEqual(list(self.resources['table_resources']),
+                             [subset_table])
+        new_table_config = self.resources['table_resources'][
+            subset_table]
+        self.assertCountEqual(['table', 'variances'],
+                              new_table_config.keys())
+
+        exp_table = self.table
+        obs_table = new_table_config['table']
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
+        exp_var = self.table2
+        obs_var = new_table_config['variances']
+        assert_frame_equal(exp_var.to_dataframe(dense=True),
+                           obs_var.to_dataframe(dense=True))
+
+    def test_table_with_taxonomy_and_variance(self):
+        subset_table = 'table-with-taxonomy-and-variance'
+        config = {'table_resources': {
+            subset_table: self.config['table_resources'][subset_table]}}
+        self.resources.update(config)
+        self.assertListEqual(list(self.resources['table_resources']),
+                             [subset_table])
+        new_table_config = self.resources['table_resources'][
+            subset_table]
+        self.assertCountEqual(['table', 'variances', 'feature-data-taxonomy'],
+                              new_table_config.keys())
+
+        exp_table = self.table
+        obs_table = new_table_config['table']
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
+        exp_var = self.table2
+        obs_var = new_table_config['variances']
+        assert_frame_equal(exp_var.to_dataframe(dense=True),
+                           obs_var.to_dataframe(dense=True))
+        exp_tax = self.taxonomy_df
+        obs_tax = new_table_config['feature-data-taxonomy']
+        obs_tax['Confidence'] = obs_tax['Confidence'].astype('float')
+        assert_frame_equal(exp_tax, obs_tax)
+
+
+class TestResourceManagerQ2Parse(TempfileTestCase):
 
     def test_parse_q2_data(self):
         resource_filename = self.create_tempfile(suffix='.qza').name
@@ -103,9 +292,9 @@ class TestResourceManager(TempfileTestCase):
         )
         imported_artifact.save(resource_filename)
 
-        res = ResourceManager()
-        loaded_artifact = res._parse_q2_data(resource_filename,
-                                             SampleData[AlphaDiversity])
+        loaded_artifact = _parse_q2_data(resource_filename,
+                                         SampleData[AlphaDiversity],
+                                         view_type=pd.Series)
         assert_series_equal(test_series, loaded_artifact)
 
     def test_parse_q2_data_wrong_semantic_type(self):
@@ -119,19 +308,19 @@ class TestResourceManager(TempfileTestCase):
         )
         imported_artifact.save(resource_filename)
 
-        res = ResourceManager()
         with self.assertRaisesRegex(ConfigurationError,
                                     r"Expected (.*) "
                                     r"'SampleData\[AlphaDiversity\]'. "
                                     r"Received 'FeatureData\[Taxonomy\]'."):
-            res._parse_q2_data(resource_filename, SampleData[AlphaDiversity])
+            _parse_q2_data(resource_filename, SampleData[AlphaDiversity],
+                           view_type=pd.Series)
 
     def test_parse_q2_data_file_does_not_exist(self):
         resource_file = self.create_tempfile(suffix='.qza')
         resource_filename = resource_file.name
         resource_file.close()
 
-        res = ResourceManager()
         with self.assertRaisesRegex(ConfigurationError,
                                     r"does not exist"):
-            res._parse_q2_data(resource_filename, SampleData[AlphaDiversity])
+            _parse_q2_data(resource_filename, SampleData[AlphaDiversity],
+                           view_type=pd.Series)

--- a/microsetta_public_api/utils/__init__.py
+++ b/microsetta_public_api/utils/__init__.py
@@ -1,1 +1,3 @@
 from microsetta_public_api.utils._utils import jsonify
+
+__all__ = ['testing', 'jsonify']

--- a/microsetta_public_api/utils/__init__.py
+++ b/microsetta_public_api/utils/__init__.py
@@ -1,0 +1,1 @@
+from microsetta_public_api.utils._utils import jsonify

--- a/microsetta_public_api/utils/_utils.py
+++ b/microsetta_public_api/utils/_utils.py
@@ -1,0 +1,5 @@
+from flask import jsonify as flask_jsonify
+
+
+def jsonify(*args, **kwargs):
+    return flask_jsonify(*args, **kwargs)

--- a/microsetta_public_api/utils/_utils.py
+++ b/microsetta_public_api/utils/_utils.py
@@ -3,3 +3,19 @@ from flask import jsonify as flask_jsonify
 
 def jsonify(*args, **kwargs):
     return flask_jsonify(*args, **kwargs)
+
+
+def validate_resource(available, name, type_):
+    if name not in available:
+        return jsonify(error=404,
+                       text=f"Requested {type_}: '{name}' "
+                            f"is unavailable. Available {type_}(s): "
+                            f"{available}"), 404
+
+
+def check_missing_ids(missing_ids, alpha_metric, type_):
+    if len(missing_ids) > 0:
+        return jsonify(missing_ids=missing_ids,
+                       error=404, text=f"Sample ID(s) not found for "
+                                       f"{type_}: {alpha_metric}"), \
+               404

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 import microsetta_public_api
 import microsetta_public_api.server
 import microsetta_public_api.utils._utils
+from microsetta_public_api import config
+from microsetta_public_api.resources import resources
 
 
 class TempfileTestCase(TestCase):
@@ -113,3 +115,15 @@ class MockedJsonifyTestCase(TestCase):
                 patcher.stop()
         else:
             self.jsonify_patcher.stop()
+
+
+class ConfigTestCase(TestCase):
+
+    def setUp(self):
+        self._config_copy = config.resources.copy()
+        self._resources_copy = resources.copy()
+
+    def tearDown(self):
+        config.resources = self._config_copy
+        resources.clear()
+        dict.update(resources, self._resources_copy)

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -3,11 +3,11 @@ import json
 import types
 import tempfile
 from unittest.case import TestCase
+from unittest.mock import patch
 
 import microsetta_public_api
 import microsetta_public_api.server
 import microsetta_public_api.utils._utils
-from microsetta_public_api.api.diversity import alpha as alpha_imp
 
 
 class TempfileTestCase(TestCase):
@@ -95,10 +95,11 @@ def mocked_jsonify(*args, **kwargs):
 class MockedJsonifyTestCase(TestCase):
 
     def setUp(self):
-        # monkey patch jsonify, then restore it after these tests are complete
-        self.old_jsonify = _copy_func(
-            microsetta_public_api.utils._utils.jsonify)
-        microsetta_public_api.utils._utils.jsonify = mocked_jsonify
+        self.jsonify_patcher = patch(
+            self.jsonify_to_patch,
+            new=mocked_jsonify,
+        )
+        self.mock_jsonify = self.jsonify_patcher.start()
 
     def tearDown(self):
-        microsetta_public_api.utils._utils.jsonify = self.old_jsonify
+        self.jsonify_patcher.stop()

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -95,11 +95,21 @@ def mocked_jsonify(*args, **kwargs):
 class MockedJsonifyTestCase(TestCase):
 
     def setUp(self):
-        self.jsonify_patcher = patch(
-            self.jsonify_to_patch,
-            new=mocked_jsonify,
-        )
-        self.mock_jsonify = self.jsonify_patcher.start()
+        if isinstance(self.jsonify_to_patch, str):
+            self.jsonify_patcher = patch(
+                self.jsonify_to_patch,
+                new=mocked_jsonify,
+            )
+            self.mock_jsonify = self.jsonify_patcher.start()
+        else:
+            self.jsonify_patcher = [patch(jsonify_, new=mocked_jsonify) for
+                                    jsonify_ in self.jsonify_to_patch]
+            self.mock_jsonify = [patcher.start() for
+                                 patcher in self.jsonify_patcher]
 
     def tearDown(self):
-        self.jsonify_patcher.stop()
+        if isinstance(self.mock_jsonify, list):
+            for patcher in self.jsonify_patcher:
+                patcher.stop()
+        else:
+            self.jsonify_patcher.stop()

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -6,6 +6,7 @@ from unittest.case import TestCase
 
 import microsetta_public_api
 import microsetta_public_api.server
+import microsetta_public_api.utils._utils
 from microsetta_public_api.api.diversity import alpha as alpha_imp
 
 
@@ -95,8 +96,9 @@ class MockedJsonifyTestCase(TestCase):
 
     def setUp(self):
         # monkey patch jsonify, then restore it after these tests are complete
-        self.old_jsonify = _copy_func(alpha_imp.jsonify)
-        alpha_imp.jsonify = mocked_jsonify
+        self.old_jsonify = _copy_func(
+            microsetta_public_api.utils._utils.jsonify)
+        microsetta_public_api.utils._utils.jsonify = mocked_jsonify
 
     def tearDown(self):
-        alpha_imp.jsonify = self.old_jsonify
+        microsetta_public_api.utils._utils.jsonify = self.old_jsonify


### PR DESCRIPTION
This PR adds the full fledged taxonomy feature to the API.

It basically exposes the `Taxonomy.get_group` function the the API.
There is support for adding both Q2 FeatureTables and biom tables, along with `FeatureData[Taxonomy]` to the server.

There is also a ton of testing to go along with these changes, some modularity improvements, and a number of utility updates.