### PR TITLE
Add REST endpoints for filtering samples in metadata by age and BMI

### DIFF
--- a/microsetta_public_api/api/metadata.py
+++ b/microsetta_public_api/api/metadata.py
@@ -1,0 +1,6 @@
+def category_values(category):
+    pass
+
+
+def filter_sample_ids(query):
+    pass

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -61,6 +61,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/sampleIdList"
+        '404':
+          $ref: '#/components/responses/404NotFound'
 
 
   '/diversity/metrics/alpha/available':

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -7,6 +7,61 @@ servers:
   - url: '/api'
 
 paths:
+  '/metadata/sample-ids':
+    get:
+      operationId: microsetta_public_api.api.metadata.filter_sample_ids
+      tags:
+        - Metadata
+      summary: Get samples associated with query
+      description: Get samples associated with query
+      parameters:
+        - in: query
+          name: query
+          schema:
+            type: object
+            properties:
+              age_cat:
+                type: string
+                example: '30s'
+              bmi_cat:
+                type: string
+                example: 'normal'
+      responses:
+        '200':
+          description: Successfully returned sample ids
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/sampleIdList"
+
+  '/metadata/category/values/{category}':
+    get:
+      operationId: microsetta_public_api.api.metadata.category_values
+      tags:
+        - Metadata
+      summary: Get values associated with metadata category
+      description: Get values associated with metadata category
+      parameters:
+        - in: path
+          name: category
+          description: Metadata category to return values of
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successfuly returned category values
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  oneOf:
+                    - type: string
+                    - type: number
+        '404':
+            $ref: '#/components/responses/404NotFound'
+
   '/diversity/metrics/alpha/available':
     get:
       operationId: microsetta_public_api.api.diversity.alpha.available_metrics_alpha

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -7,33 +7,6 @@ servers:
   - url: '/api'
 
 paths:
-  '/metadata/sample-ids':
-    get:
-      operationId: microsetta_public_api.api.metadata.filter_sample_ids
-      tags:
-        - Metadata
-      summary: Get samples associated with query
-      description: Get samples associated with query
-      parameters:
-        - in: query
-          name: query
-          schema:
-            type: object
-            properties:
-              age_cat:
-                type: string
-                example: '30s'
-              bmi_cat:
-                type: string
-                example: 'normal'
-      responses:
-        '200':
-          description: Successfully returned sample ids
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/sampleIdList"
-
   '/metadata/category/values/{category}':
     get:
       operationId: microsetta_public_api.api.metadata.category_values
@@ -61,6 +34,34 @@ paths:
                     - type: number
         '404':
             $ref: '#/components/responses/404NotFound'
+
+  '/metadata/sample-ids':
+    get:
+      operationId: microsetta_public_api.api.metadata.filter_sample_ids
+      tags:
+        - Metadata
+      summary: Get samples associated with query
+      description: Get samples associated with query
+      parameters:
+        - in: query
+          name: age_cat
+          schema:
+            type: string
+            example: '30s'
+        - in: query
+          name: bmi
+          schema:
+            type: string
+            example: 'normal'
+
+      responses:
+        '200':
+          description: Successfully returned sample ids
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/sampleIdList"
+
 
   '/diversity/metrics/alpha/available':
     get:
@@ -367,6 +368,7 @@ components:
       type: object
       required:
         - sample_ids
+      additionalProperties: False
       properties:
         sample_ids:
           type: array

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -49,10 +49,10 @@ paths:
             type: string
             example: '30s'
         - in: query
-          name: bmi
+          name: bmi_cat
           schema:
             type: string
-            example: 'normal'
+            example: 'Normal'
 
       responses:
         '200':

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -4,6 +4,139 @@ import json
 from microsetta_public_api.utils.testing import FlaskTests
 
 
+class MetadataSampleIdsTests(FlaskTests):
+
+    def setUp(self):
+        super().setUp()
+        self.patcher = patch(
+            'microsetta_public_api.api.metadata.filter_sample_ids')
+        self.mock_method = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_metadata_sample_ids_returns_simple(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                    'sample-2',
+                ]
+            })
+
+        _, self.client = self.build_app_test_client()
+        exp_ids = ['sample-1', 'sample-2']
+        response = self.client.get(
+            "/api/metadata/sample-ids?age_cat=30s&bmi=normal")
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+        self.mock_method.assert_called_with(age_cat='30s', bmi='normal')
+
+    def test_metadata_sample_ids_returns_empty(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'sample_ids': [
+                ]
+            })
+
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
+            "/api/metadata/sample-ids?age_cat=30s&bmi=normal")
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertEqual(obs['sample_ids'], [])
+
+    def test_metadata_sample_ids_returns_extra_categories(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                ],
+                'some-extra-cat': ['stuff'],
+            })
+
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
+            "/api/metadata/sample-ids?age_cat=30s&bmi=normal")
+        self.assertStatusCode(500, response)
+
+    def test_metadata_sample_ids_get_extra_category_errors(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                    'sample-2',
+                ],
+                'some-extra-cat': ['stuff'],
+            })
+
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
+            "/api/metadata/sample-ids?age_cat=30s&bmi=normal&gimme_cat"
+            "=something")
+        self.assertStatusCode(500, response)
+
+    def test_metadata_sample_ids_get_age_cat_succeeds(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                    'sample-2',
+                ],
+            })
+
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
+            "/api/metadata/sample-ids?age_cat=30s")
+        exp_ids = ['sample-1', 'sample-2']
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+        self.mock_method.assert_called_with(age_cat='30s')
+
+    def test_metadata_sample_ids_get_bmi_succeeds(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                    'sample-2',
+                ],
+            })
+
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
+            "/api/metadata/sample-ids?bmi=normal")
+        exp_ids = ['sample-1', 'sample-2']
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+        self.mock_method.assert_called_with(bmi='normal')
+
+    def test_metadata_sample_ids_get_null_parameters_succeeds(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                    'sample-2',
+                ],
+            })
+
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
+            "/api/metadata/sample-ids")
+        exp_ids = ['sample-1', 'sample-2']
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+        self.mock_method.assert_called_with()
+
+
 class AlphaDiversityTestCase(FlaskTests):
 
     def setUp(self):

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -135,35 +135,6 @@ class MetadataSampleIdsTests(FlaskTests):
         self.assertCountEqual(['sample_ids'], obs.keys())
         self.assertEqual(obs['sample_ids'], [])
 
-    def test_metadata_sample_ids_returns_extra_categories(self):
-        with self.app_context():
-            self.mock_method.return_value = jsonify({
-                'sample_ids': [
-                    'sample-1',
-                ],
-                'some-extra-cat': ['stuff'],
-            })
-
-        _, self.client = self.build_app_test_client()
-        response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal")
-        self.assertStatusCode(500, response)
-
-    def test_metadata_sample_ids_get_extra_category_in_response_errors(self):
-        with self.app_context():
-            self.mock_method.return_value = jsonify({
-                'sample_ids': [
-                    'sample-1',
-                    'sample-2',
-                ],
-                'some-extra-cat': ['stuff'],
-            })
-
-        _, self.client = self.build_app_test_client()
-        response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal")
-        self.assertStatusCode(500, response)
-
     def test_metadata_sample_ids_get_extra_category_in_query_404(self):
         with self.app_context():
             self.mock_method.return_value = jsonify({

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -4,6 +4,92 @@ import json
 from microsetta_public_api.utils.testing import FlaskTests
 
 
+class MetadataCategoryTests(FlaskTests):
+
+    def setUp(self):
+        super().setUp()
+        self.patcher = patch(
+            'microsetta_public_api.api.metadata.category_values')
+        self.mock_method = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_metadata_category_values_returns_string_array(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify([
+                '20s',
+                '30s',
+                '40s',
+                '50',
+            ])
+        _, self.client = self.build_app_test_client()
+        exp = ['20s', '30s', '40s', '50']
+        response = self.client.get(
+            "/api/metadata/category/values/age_cat")
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertListEqual(exp, obs)
+        self.mock_method.assert_called_with(category='age_cat')
+
+    def test_metadata_category_values_returns_numeric_array(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify([
+                20,
+                30,
+                7.15,
+                8.25,
+            ])
+        _, self.client = self.build_app_test_client()
+        exp = [20, 30, 7.15, 8.25]
+        response = self.client.get(
+            "/api/metadata/category/values/age_cat")
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertListEqual(exp, obs)
+        self.mock_method.assert_called_with(category='age_cat')
+
+    def test_metadata_category_values_returns_mixed_type_array(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify([
+                '20s',
+                30,
+                7.15,
+                8.25,
+            ])
+        _, self.client = self.build_app_test_client()
+        exp = ['20s', 30, 7.15, 8.25]
+        response = self.client.get(
+            "/api/metadata/category/values/age_cat")
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertListEqual(exp, obs)
+        self.mock_method.assert_called_with(category='age_cat')
+
+    def test_metadata_category_values_returns_empty(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify([])
+        _, self.client = self.build_app_test_client()
+        exp = []
+        response = self.client.get(
+            "/api/metadata/category/values/age_cat")
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertListEqual(exp, obs)
+        self.mock_method.assert_called_with(category='age_cat')
+
+    def test_metadata_category_values_returns_404(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify(
+                error=404, text='Unknown Category',
+            ), 404
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
+            "/api/metadata/category/values/age_cat")
+        self.assertStatusCode(404, response)
+        self.mock_method.assert_called_with(category='age_cat')
+
+
 class MetadataSampleIdsTests(FlaskTests):
 
     def setUp(self):

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -149,7 +149,7 @@ class MetadataSampleIdsTests(FlaskTests):
             "/api/metadata/sample-ids?age_cat=30s&bmi=normal")
         self.assertStatusCode(500, response)
 
-    def test_metadata_sample_ids_get_extra_category_errors(self):
+    def test_metadata_sample_ids_get_extra_category_in_response_errors(self):
         with self.app_context():
             self.mock_method.return_value = jsonify({
                 'sample_ids': [
@@ -161,9 +161,21 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
+            "/api/metadata/sample-ids?age_cat=30s&bmi=normal")
+        self.assertStatusCode(500, response)
+
+    def test_metadata_sample_ids_get_extra_category_in_query_404(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'text': "Metadata category: 'gimme_cat' does not exits.",
+                'error': 404
+            }), 404
+
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
             "/api/metadata/sample-ids?age_cat=30s&bmi=normal&gimme_cat"
             "=something")
-        self.assertStatusCode(500, response)
+        self.assertStatusCode(404, response)
 
     def test_metadata_sample_ids_get_age_cat_succeeds(self):
         with self.app_context():

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -113,12 +113,12 @@ class MetadataSampleIdsTests(FlaskTests):
         _, self.client = self.build_app_test_client()
         exp_ids = ['sample-1', 'sample-2']
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi=normal")
+            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal")
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())
         self.assertCountEqual(obs['sample_ids'], exp_ids)
-        self.mock_method.assert_called_with(age_cat='30s', bmi='normal')
+        self.mock_method.assert_called_with(age_cat='30s', bmi_cat='normal')
 
     def test_metadata_sample_ids_returns_empty(self):
         with self.app_context():
@@ -129,7 +129,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi=normal")
+            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal")
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())
@@ -146,7 +146,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi=normal")
+            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal")
         self.assertStatusCode(500, response)
 
     def test_metadata_sample_ids_get_extra_category_in_response_errors(self):
@@ -161,7 +161,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi=normal")
+            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal")
         self.assertStatusCode(500, response)
 
     def test_metadata_sample_ids_get_extra_category_in_query_404(self):
@@ -173,7 +173,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi=normal&gimme_cat"
+            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal&gimme_cat"
             "=something")
         self.assertStatusCode(404, response)
 
@@ -207,13 +207,13 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?bmi=normal")
+            "/api/metadata/sample-ids?bmi_cat=normal")
         exp_ids = ['sample-1', 'sample-2']
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())
         self.assertCountEqual(obs['sample_ids'], exp_ids)
-        self.mock_method.assert_called_with(bmi='normal')
+        self.mock_method.assert_called_with(bmi_cat='normal')
 
     def test_metadata_sample_ids_get_null_parameters_succeeds(self):
         with self.app_context():

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -43,6 +43,14 @@ class FlaskTests(TestCase):
         client = app.app.test_client()
         return app, client
 
+    def assertStatusCode(self, exp_code, response):
+        try:
+            status_code = response.status_code
+            self.assertEqual(exp_code, status_code)
+        except AssertionError:
+            raise AssertionError(f'{exp_code} != {status_code}'
+                                 f'\nRecieved response data: {response.data}')
+
 
 def _copy_func(f, name=None):
     """


### PR DESCRIPTION
This PR includes a draft of the swagger yaml and tests for responses that should allow for API calls like:
```
GET …/metadata/category/values/age_cat
```
which would return something like “20s, 30s, 40s…”, the specific values of the category
and
```
GET …/metadata/sample-ids/age_cat=<a-specific-value>&bmi_cat=<a-specific-value>
```
which would return the sample ids that meet the age and bmi criteria