### PR TITLE
Add metadata resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,15 @@ in a configuration `JSON`. The value is expected to be a dictionary of `"<metric
 where `"<metric>"` is the name of the metric stored by the QZA and `"</file/path/name.qza>"` is a path to the QZA
 on the host server.
 
+### Features tables (with taxonomy)
 The server can also be configured to serve information from feature tables with corresponding taxonomic
 feature data. Tables can either be QZA `FeatureTable`'s or biom tables. If a `biom` table is supplied,
 the `"table-format": "biom"` option must be specified. Taxonomy data is accepted with the
 `"feature-data-taxonomy"` keyword, which should correspond to the filepath to a QIIME2 `FeatureData[Taxonomy]`.
+
+### Metadata
+The server can be configured to contain metadata, by adding a  `"metadata"` keyword to the config,
+that gives a path to a QIIME2 formatted metadata file.
 
 `sample_config.json`:
 ```json
@@ -63,7 +68,8 @@ the `"table-format": "biom"` option must be specified. Taxonomy data is accepted
       "table-format": "biom",
       "feature-data-taxonomy": "/path/to/a/taxonomy-data.qza"
     }
-  }
+  },
+  "metadata": "/path/to/some/metadata.txt"
 }
 ```
 

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -207,7 +207,8 @@ class ResourceManager(dict):
         ...             'variances': '/a/variance/feature-table.qza',
         ...             'q2-type': FeatureTable[Frequency],
         ...         },
-        ...     }
+        ...     },
+        ...     metadata='/path/to/some/metadata.txt',
         ...     some_other_resource='here is a string resource',
         ...     )
 

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -2,13 +2,8 @@ import pandas as pd
 import numpy as np
 import biom
 from biom.util import biom_open
-<<<<<<< HEAD
-from pandas.util.testing import assert_series_equal, assert_frame_equal
-from qiime2 import Artifact
-=======
 from pandas.testing import assert_series_equal, assert_frame_equal
 from qiime2 import Artifact, Metadata
->>>>>>> debug-md-ci-testing
 from q2_types.sample_data import SampleData, AlphaDiversity
 from q2_types.feature_table import FeatureTable, Frequency
 from qiime2.metadata.io import MetadataFileError

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -39,6 +39,13 @@ class TestResourceManagerUpdateMetadata(TempfileTestCase):
         with self.assertRaises(MetadataFileError):
             self.resources.update({'metadata': self.metadata_fp_dne})
 
+    def test_resource_manager_update_metadata_non_string(self):
+        with self.assertRaises(MetadataFileError):
+            self.resources.update({'metadata': {'put': 'some',
+                                                'other': 'type'}})
+        with self.assertRaises(MetadataFileError):
+            self.resources.update({'metadata': 9})
+
 
 class TestResourceManagerUpdateAlpha(TempfileTestCase):
 

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -6,12 +6,15 @@ from pandas.util.testing import assert_series_equal, assert_frame_equal
 from qiime2 import Artifact
 from q2_types.sample_data import SampleData, AlphaDiversity
 from q2_types.feature_table import FeatureTable, Frequency
+from qiime2.metadata.io import MetadataFileError
 
 from microsetta_public_api.exceptions import ConfigurationError
 from microsetta_public_api.utils.testing import TempfileTestCase
 from microsetta_public_api.resources import ResourceManager, _parse_q2_data
 
 
+if False:
+    raise MetadataFileError('darn')
 # remember to put back 'from qiime2 import Metadata'
 # remember to put back 'from qiime2.metadata.io import MetadataFileError
 # class TestResourceManagerUpdateMetadata(TempfileTestCase):

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -3,48 +3,49 @@ import numpy as np
 import biom
 from biom.util import biom_open
 from pandas.util.testing import assert_series_equal, assert_frame_equal
-from qiime2 import Artifact, Metadata
+from qiime2 import Artifact
 from q2_types.sample_data import SampleData, AlphaDiversity
 from q2_types.feature_table import FeatureTable, Frequency
-from qiime2.metadata.io import MetadataFileError
 
 from microsetta_public_api.exceptions import ConfigurationError
 from microsetta_public_api.utils.testing import TempfileTestCase
 from microsetta_public_api.resources import ResourceManager, _parse_q2_data
 
 
-class TestResourceManagerUpdateMetadata(TempfileTestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.metadata_fp = self.create_tempfile(suffix='.txt').name
-        self.metadata_fh2 = self.create_tempfile(suffix='.txt')
-        self.metadata_fh2.close()
-        self.metadata_fp_dne = self.metadata_fh2.name
-        self.test_metadata = pd.DataFrame({
-            'age_cat': ['30s', '40s', '50s', '30s'],
-            'num': [7.15, 9.04, 8.25, 7.24],
-            }, index=pd.Series(['a', 'b', 'c', 'd'], name='#SampleID')
-        )
-        self.q2_metadata = Metadata(self.test_metadata)
-        self.q2_metadata.save(self.metadata_fp)
-        self.resources = ResourceManager()
-
-    def test_resource_manager_update_metadata(self):
-        self.resources.update({'metadata': self.metadata_fp})
-        self.assertCountEqual(['metadata'], self.resources.keys())
-        assert_frame_equal(self.resources['metadata'], self.test_metadata)
-
-    def test_resource_manager_update_metadata_does_not_exist(self):
-        with self.assertRaises(MetadataFileError):
-            self.resources.update({'metadata': self.metadata_fp_dne})
-
-    def test_resource_manager_update_metadata_non_string(self):
-        with self.assertRaises(MetadataFileError):
-            self.resources.update({'metadata': {'put': 'some',
-                                                'other': 'type'}})
-        with self.assertRaises(MetadataFileError):
-            self.resources.update({'metadata': 9})
+# remember to put back 'from qiime2 import Metadata'
+# remember to put back 'from qiime2.metadata.io import MetadataFileError
+# class TestResourceManagerUpdateMetadata(TempfileTestCase):
+#
+#     def setUp(self):
+#         super().setUp()
+#         self.metadata_fp = self.create_tempfile(suffix='.txt').name
+#         self.metadata_fh2 = self.create_tempfile(suffix='.txt')
+#         self.metadata_fh2.close()
+#         self.metadata_fp_dne = self.metadata_fh2.name
+#         self.test_metadata = pd.DataFrame({
+#             'age_cat': ['30s', '40s', '50s', '30s'],
+#             'num': [7.15, 9.04, 8.25, 7.24],
+#             }, index=pd.Series(['a', 'b', 'c', 'd'], name='#SampleID')
+#         )
+#         self.q2_metadata = Metadata(self.test_metadata)
+#         self.q2_metadata.save(self.metadata_fp)
+#         self.resources = ResourceManager()
+#
+#     def test_resource_manager_update_metadata(self):
+#         self.resources.update({'metadata': self.metadata_fp})
+#         self.assertCountEqual(['metadata'], self.resources.keys())
+#         assert_frame_equal(self.resources['metadata'], self.test_metadata)
+#
+#     def test_resource_manager_update_metadata_does_not_exist(self):
+#         with self.assertRaises(MetadataFileError):
+#             self.resources.update({'metadata': self.metadata_fp_dne})
+#
+#     def test_resource_manager_update_metadata_non_string(self):
+#         with self.assertRaises(MetadataFileError):
+#             self.resources.update({'metadata': {'put': 'some',
+#                                                 'other': 'type'}})
+#         with self.assertRaises(MetadataFileError):
+#             self.resources.update({'metadata': 9})
 
 
 class TestResourceManagerUpdateAlpha(TempfileTestCase):

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -3,13 +3,41 @@ import numpy as np
 import biom
 from biom.util import biom_open
 from pandas.util.testing import assert_series_equal, assert_frame_equal
-from qiime2 import Artifact
+from qiime2 import Artifact, Metadata
 from q2_types.sample_data import SampleData, AlphaDiversity
 from q2_types.feature_table import FeatureTable, Frequency
+from qiime2.metadata.io import MetadataFileError
 
 from microsetta_public_api.exceptions import ConfigurationError
 from microsetta_public_api.utils.testing import TempfileTestCase
 from microsetta_public_api.resources import ResourceManager, _parse_q2_data
+
+
+class TestResourceManagerUpdateMetadata(TempfileTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.metadata_fp = self.create_tempfile(suffix='.txt').name
+        self.metadata_fh2 = self.create_tempfile(suffix='.txt')
+        self.metadata_fh2.close()
+        self.metadata_fp_dne = self.metadata_fh2.name
+        self.test_metadata = pd.DataFrame({
+            'age_cat': ['30s', '40s', '50s', '30s'],
+            'num': [7.15, 9.04, 8.25, 7.24],
+            }, index=pd.Series(['a', 'b', 'c', 'd'], name='#SampleID')
+        )
+        self.q2_metadata = Metadata(self.test_metadata)
+        self.q2_metadata.save(self.metadata_fp)
+        self.resources = ResourceManager()
+
+    def test_resource_manager_update_metadata(self):
+        self.resources.update({'metadata': self.metadata_fp})
+        self.assertCountEqual(['metadata'], self.resources.keys())
+        assert_frame_equal(self.resources['metadata'], self.test_metadata)
+
+    def test_resource_manager_update_metadata_does_not_exist(self):
+        with self.assertRaises(MetadataFileError):
+            self.resources.update({'metadata': self.metadata_fp_dne})
 
 
 class TestResourceManagerUpdateAlpha(TempfileTestCase):

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -27,13 +27,7 @@ class TempfileTestCase(TestCase):
 
     def tearDown(self):
         for tempfile_ in self._tempfiles:
-            try:
-                tempfile_.close()
-            # hoping this only happens if the tempfile is closed prior to
-            #  this teardown being called... which is nice for getting paths
-            #  you know coud exist on the machine
-            except OSError:
-                pass
+            tempfile_.close()
 
 
 class FlaskTests(TestCase):

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -27,7 +27,13 @@ class TempfileTestCase(TestCase):
 
     def tearDown(self):
         for tempfile_ in self._tempfiles:
-            tempfile_.close()
+            try:
+                tempfile_.close()
+            # hoping this only happens if the tempfile is closed prior to
+            #  this teardown being called... which is nice for getting paths
+            #  you know coud exist on the machine
+            except OSError:
+                pass
 
 
 class FlaskTests(TestCase):


### PR DESCRIPTION
This PR serves to add the ability to configure metadata to add to the server.

By adding a
```
{
...
   'metadata': '/some/system/path.txt'
...
}
```
keyword to the config, with the path referring to some QIIME2 formatted metadata file, you can add a single metadata file to the server.