### PR TITLE
Metadata repo for age cat bmi queries

### DIFF
--- a/microsetta_public_api/repo/_metadata_repo.py
+++ b/microsetta_public_api/repo/_metadata_repo.py
@@ -1,0 +1,17 @@
+from microsetta_public_api.resources import resources
+
+
+class MetadataRepo:
+
+    def __init__(self):
+        raise NotImplementedError()
+
+    @@property
+    def categories(self):
+        raise NotImplementedError()
+
+    def category_values(self, category):
+        raise NotImplementedError()
+
+    def sample_id_matches(self, query):
+        raise NotImplementedError()

--- a/microsetta_public_api/repo/_metadata_repo.py
+++ b/microsetta_public_api/repo/_metadata_repo.py
@@ -42,14 +42,45 @@ class MetadataRepo:
         return list(self._metadata.columns)
 
     def category_values(self, category):
+        """
+
+        Parameters
+        ----------
+        category : str
+            Metadata category to return the values of
+
+        Returns
+        -------
+        list
+            Contains the unique values in the metadata category
+
+        Raises
+        ------
+        ValueError
+            If `category` is not an existing category in the metadata
+
+        """
         if category not in self._metadata.columns:
             raise ValueError(f'No category with name `{category}`')
         else:
             return list(self._metadata[category].unique())
 
     def sample_id_matches(self, query):
-        slice = self._process_query(query)
-        return self._metadata.index[slice]
+        """
+
+        Parameters
+        ----------
+        query : dict
+            Expects a jquerybuilder formatted query
+
+        Returns
+        -------
+        list
+            The sample IDs that match the given `query`
+
+        """
+        slice_ = self._process_query(query)
+        return list(self._metadata.index[slice_])
 
     def _process_query(self, query):
         group_fields = ["condition", "rules"]

--- a/microsetta_public_api/repo/_metadata_repo.py
+++ b/microsetta_public_api/repo/_metadata_repo.py
@@ -4,14 +4,21 @@ from microsetta_public_api.resources import resources
 class MetadataRepo:
 
     def __init__(self):
-        raise NotImplementedError()
+        self._metadata = resources.get('metadata', pd.DataFrame())
 
-    @@property
+    @property
+    def metadata(self):
+        return self._metadata
+
+    @property
     def categories(self):
-        raise NotImplementedError()
+        return list(self._metadata.columns)
 
     def category_values(self, category):
-        raise NotImplementedError()
+        if category not in self._metadata.columns:
+            raise ValueError(f'No category with name `{category}`')
+        else:
+            return list(self._metadata[category].unique())
 
     def sample_id_matches(self, query):
         raise NotImplementedError()

--- a/microsetta_public_api/repo/_metadata_repo.py
+++ b/microsetta_public_api/repo/_metadata_repo.py
@@ -77,4 +77,3 @@ class MetadataRepo:
         if len(list_of_df) > 0:
             return pd.concat(list_of_df, **concat_kwargs)
         return pd.DataFrame(pd.Series(True, index=self._metadata.index))
-

--- a/microsetta_public_api/repo/_metadata_repo.py
+++ b/microsetta_public_api/repo/_metadata_repo.py
@@ -43,7 +43,6 @@ class MetadataRepo:
 
     def category_values(self, category):
         """
-        
         Parameters
         ----------
         category : str

--- a/microsetta_public_api/repo/tests/test_metadata_repo.py
+++ b/microsetta_public_api/repo/tests/test_metadata_repo.py
@@ -1,0 +1,87 @@
+import pandas as pd
+from microsetta_public_api import config
+from microsetta_public_api.resources import resources
+from microsetta_public_api.utils.testing import (TempfileTestCase,
+                                                 ConfigTestCase)
+from microsetta_public_api.repo._metadata_repo import MetadataRepo
+
+
+class TestMetadataRepo(TempfileTestCase, ConfigTestCase):
+
+    def setUp(self):
+        TempfileTestCase.setUp(self)
+        ConfigTestCase.setUp(self)
+
+        self.metadata_filename = self.create_tempfile(suffix='.qza').name
+
+        self.test_metadata = pd.DataFrame({
+                'age_cat': ['30s', '40s', '50s', '30s'],
+                'num_cat': [7.24, 7.24, 8.25, 7.24],
+            }, index=pd.Series(['a', 'b', 'c', 'd'], name='#SampleID')
+        )
+        config.resources.update({'metadata': self.test_metadata})
+        self.repo = MetadataRepo()
+
+    def tearDown(self):
+        TempfileTestCase.tearDown(self)
+        ConfigTestCase.tearDown(self)
+
+    def test_categories(self):
+        exp = ['age_cat', 'num']
+        obs = self.repo.categories
+        self.assertCountEqual(exp, obs)
+
+    def test_category_values_string(self):
+        exp = ['30s', '40s', '50s']
+        obs = self.repo.category_values('age_cat')
+        self.assertCountEqual(exp, obs)
+
+    def test_category_values_numeric(self):
+        exp = [7.24, 8.25]
+        obs = self.repo.category_values('num')
+        self.assertCountEqual(exp, obs)
+
+    def test_category_sample_id_matches_query_multiple_category(self):
+        exp = ['a', 'd']
+        query = {
+            "condition": "AND",
+            "rules": [
+                {
+                    "id": "age_cat",
+                    "operator": "equal",
+                    "value": "30s",
+                },
+                {
+                    "id": "num_cat",
+                    "operator": "equal",
+                    "value": 7.24,
+                }
+            ]
+        }
+        obs = self.repo.sample_id_matches(query)
+        self.assertCountEqual(exp, obs)
+
+    def test_category_sample_id_matches_query_single_category(self):
+        exp = ['c']
+        query = {
+            "condition": "AND",
+            "rules": [
+                {
+                    "id": "age_cat",
+                    "operator": "equal",
+                    "value": "50s",
+                },
+            ]
+        }
+        obs = self.repo.sample_id_matches(query)
+        self.assertCountEqual(exp, obs)
+
+    def test_category_sample_id_matches_query_no_category(self):
+        exp = ['a', 'b', 'c', 'd']
+        query = {
+            "condition": "AND",
+            "rules": [
+            ]
+        }
+        obs = self.repo.sample_id_matches(query)
+        self.assertCountEqual(exp, obs)

--- a/microsetta_public_api/repo/tests/test_metadata_repo.py
+++ b/microsetta_public_api/repo/tests/test_metadata_repo.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from qiime2 import Metadata
 from microsetta_public_api import config
 from microsetta_public_api.resources import resources
 from microsetta_public_api.utils.testing import (TempfileTestCase,
@@ -19,7 +20,9 @@ class TestMetadataRepo(TempfileTestCase, ConfigTestCase):
                 'num_cat': [7.24, 7.24, 8.25, 7.24],
             }, index=pd.Series(['a', 'b', 'c', 'd'], name='#SampleID')
         )
-        config.resources.update({'metadata': self.test_metadata})
+        Metadata(self.test_metadata).save(self.metadata_filename)
+        config.resources.update({'metadata': self.metadata_filename})
+        resources.update(config.resources)
         self.repo = MetadataRepo()
 
     def tearDown(self):
@@ -27,7 +30,7 @@ class TestMetadataRepo(TempfileTestCase, ConfigTestCase):
         ConfigTestCase.tearDown(self)
 
     def test_categories(self):
-        exp = ['age_cat', 'num']
+        exp = ['age_cat', 'num_cat']
         obs = self.repo.categories
         self.assertCountEqual(exp, obs)
 
@@ -38,7 +41,7 @@ class TestMetadataRepo(TempfileTestCase, ConfigTestCase):
 
     def test_category_values_numeric(self):
         exp = [7.24, 8.25]
-        obs = self.repo.category_values('num')
+        obs = self.repo.category_values('num_cat')
         self.assertCountEqual(exp, obs)
 
     def test_category_sample_id_matches_query_multiple_category(self):

--- a/microsetta_public_api/repo/tests/test_metadata_repo.py
+++ b/microsetta_public_api/repo/tests/test_metadata_repo.py
@@ -18,6 +18,7 @@ class TestMetadataRepo(TempfileTestCase, ConfigTestCase):
         self.test_metadata = pd.DataFrame({
                 'age_cat': ['30s', '40s', '50s', '30s'],
                 'num_cat': [7.24, 7.24, 8.25, 7.24],
+                'other': [1, 2, 3, 4],
             }, index=pd.Series(['a', 'b', 'c', 'd'], name='#SampleID')
         )
         Metadata(self.test_metadata).save(self.metadata_filename)
@@ -30,7 +31,7 @@ class TestMetadataRepo(TempfileTestCase, ConfigTestCase):
         ConfigTestCase.tearDown(self)
 
     def test_categories(self):
-        exp = ['age_cat', 'num_cat']
+        exp = ['age_cat', 'num_cat', 'other']
         obs = self.repo.categories
         self.assertCountEqual(exp, obs)
 
@@ -64,6 +65,37 @@ class TestMetadataRepo(TempfileTestCase, ConfigTestCase):
         obs = self.repo.sample_id_matches(query)
         self.assertCountEqual(exp, obs)
 
+    def test_category_sample_id_matches_query_nested(self):
+        exp = ['a', 'c', 'd']
+        query = {
+            "condition": "OR",
+            "rules": [
+                {
+                    "condition": "AND",
+                    "rules": [
+                        {
+                            "id": "age_cat",
+                            "operator": "equal",
+                            "value": "30s",
+                        },
+                        {
+                            "id": "num_cat",
+                            "operator": "equal",
+                            "value": 7.24,
+                        }
+                    ]
+
+                },
+                {
+                    "id": "other",
+                    "operator": "greater_or_equal",
+                    "value": 3,
+                },
+            ],
+        }
+        obs = self.repo.sample_id_matches(query)
+        self.assertCountEqual(exp, obs)
+
     def test_category_sample_id_matches_query_single_category(self):
         exp = ['c']
         query = {
@@ -88,3 +120,61 @@ class TestMetadataRepo(TempfileTestCase, ConfigTestCase):
         }
         obs = self.repo.sample_id_matches(query)
         self.assertCountEqual(exp, obs)
+
+    def test_category_sample_id_ill_formed_query_no_condition(self):
+        query = {
+            "rules": [
+                {
+                    "id": "age_cat",
+                    "operator": "equal",
+                    "value": "50s",
+                }
+            ]
+        }
+        with self.assertRaisesRegex(ValueError, r'does not appear to be a '
+                                                r'rule or a group'):
+            self.repo.sample_id_matches(query)
+
+    def test_category_sample_id_ill_formed_query_bad_rule(self):
+        query = {
+            "condition": "AND",
+            "rules": [
+                {
+                    "id": "age_cat",
+                    "value": "50s",
+                }
+            ]
+        }
+        with self.assertRaisesRegex(ValueError, r'does not appear to be a '
+                                                r'rule or a group'):
+            self.repo.sample_id_matches(query)
+
+    def test_category_sample_id_ill_formed_query_unsupported_condition(self):
+        query = {
+            "condition": "XOR",
+            "rules": [
+                {
+                    "id": "age_cat",
+                    "value": "50s",
+                    "operator": "equal"
+                }
+            ]
+        }
+        with self.assertRaisesRegex(ValueError, r'Only conditions in (.*) '
+                                                r'are supported. Got '):
+            self.repo.sample_id_matches(query)
+
+    def test_category_sample_id_ill_formed_query_unsupported_operator(self):
+        query = {
+            "condition": "AND",
+            "rules": [
+                {
+                    "id": "age_cat",
+                    "value": "50s",
+                    "operator": "something_weird"
+                }
+            ]
+        }
+        with self.assertRaisesRegex(ValueError, r'Only operators in (.*) '
+                                                r'are supported. Got '):
+            self.repo.sample_id_matches(query)


### PR DESCRIPTION
This PR adds the metadata repo, used for finding out information about the metadata, including filtering for sample ids that meet certain criteria.

Note that the `query` parameter taken by `MetadataRepo.sample_id_matches` is expected to be approximately of the form output by [jQuery QueryBuilder](https://querybuilder.js.org/). This should hopefully withstand some amount of forward compatibility, but could easily be dropped for a simpler approach.

Also note that this PR branch builds on #13 so some changes will be repeats.
