### PR TITLE
BUG add ability to ignore predicates in q2 type checking

### DIFF
--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -4,6 +4,7 @@ import biom
 from copy import deepcopy
 from microsetta_public_api.exceptions import ConfigurationError
 from qiime2 import Artifact
+from qiime2.core.type.grammar import TypeExp
 from q2_types.sample_data import AlphaDiversity, SampleData
 from q2_types.feature_table import FeatureTable, Frequency
 from q2_types.feature_data import FeatureData, Taxonomy
@@ -86,13 +87,18 @@ def _transform_single_table(dict_, resource_name):
     return new_resource
 
 
-def _parse_q2_data(filepath, semantic_type, view_type=None):
+def _parse_q2_data(filepath, semantic_type, view_type=None,
+                   ignore_predicate=True):
     try:
         data = Artifact.load(filepath)
     except ValueError as e:
         raise ConfigurationError(*e.args)
 
-    if data.type != semantic_type:
+    data_type = data.type
+    if ignore_predicate:
+        data_type = TypeExp(data_type.template, fields=data_type.fields)
+
+    if data_type != semantic_type:
         raise ConfigurationError(f"Expected QZA '{filepath}' to have type "
                                  f"'{semantic_type}'. "
                                  f"Received '{data.type}'.")

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -333,6 +333,21 @@ class TestResourceManagerQ2Parse(TempfileTestCase):
                                          view_type=pd.Series)
         assert_series_equal(test_series, loaded_artifact)
 
+    def test_parse_q2_data_with_predicate(self):
+        resource_filename = self.create_tempfile(suffix='.qza').name
+        test_series = pd.Series({'sample1': 7.15, 'sample2': 9.04},
+                                name='chao1')
+        imported_artifact = Artifact.import_data(
+            "SampleData[AlphaDiversity] % Properties('phylogenetic')",
+            test_series
+        )
+        imported_artifact.save(resource_filename)
+
+        loaded_artifact = _parse_q2_data(resource_filename,
+                                         SampleData[AlphaDiversity],
+                                         view_type=pd.Series)
+        assert_series_equal(test_series, loaded_artifact)
+
     def test_parse_q2_data_wrong_semantic_type(self):
         resource_filename = self.create_tempfile(suffix='.qza').name
         test_series = pd.Series({'feature1': 'k__1', 'feature2': 'k__2'},


### PR DESCRIPTION
This PR allows us to ignore predicates, such as the ` % Properties('phylogenetic')` in `SampleData[AlphaDiversity]` when validating Q2 artifacts. This is the new default for now. This was creating issues when trying to add a Faith's PD artifact to my local dev server.