### PR TITLE
Metadata filter sample ids by taxonomy and alpha

### DIFF
--- a/microsetta_public_api/api/metadata.py
+++ b/microsetta_public_api/api/metadata.py
@@ -1,5 +1,7 @@
 from microsetta_public_api.repo._metadata_repo import MetadataRepo
-from microsetta_public_api.utils import jsonify
+from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
+from microsetta_public_api.repo._alpha_repo import AlphaRepo
+from microsetta_public_api.utils._utils import jsonify, validate_resource
 
 
 def category_values(category):
@@ -12,13 +14,45 @@ def category_values(category):
         return jsonify(text=text, error=404), 404
 
 
-def filter_sample_ids(**kwargs):
+def filter_sample_ids(taxonomy=None, alpha_metric=None, **kwargs):
     repo = MetadataRepo()
     query = _format_query(kwargs)
     is_invalid = _validate_query(kwargs, repo)
     if is_invalid:
         return is_invalid
     matching_ids = repo.sample_id_matches(query)
+
+    if taxonomy is not None:
+        taxonomy_repo = TaxonomyRepo()
+        available_resources = taxonomy_repo.resources()
+
+        type_ = 'resource'
+        missing_resource = validate_resource(available_resources, taxonomy,
+                                             type_)
+        if missing_resource:
+            return missing_resource
+
+        matching_ids_ = [id_ for id_ in matching_ids if
+                         taxonomy_repo.exists(id_, taxonomy)]
+        matching_ids = matching_ids_
+
+    if alpha_metric is not None:
+        alpha_repo = AlphaRepo()
+
+        # figure out if the user asked for a metric we have data on
+        available_metrics = alpha_repo.available_metrics()
+        type_ = 'metric'
+        missing_metric = validate_resource(available_metrics, alpha_metric,
+                                           type_)
+        if missing_metric:
+            return missing_metric
+
+        # make sure all of the data the samples the user asked for have values
+        # for the given metric
+        matching_ids_ = [id_ for id_ in matching_ids if
+                         alpha_repo.exists(id_, alpha_metric)]
+        matching_ids = matching_ids_
+
     return jsonify(sample_ids=matching_ids), 200
 
 

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -53,6 +53,17 @@ paths:
           schema:
             type: string
             example: 'Normal'
+        - in: query
+          name: taxonomy
+          description: Filter IDs to those present in the table associated with `taxonomy`
+          schema:
+            type: string
+            example: 'genus-level-taxonomy'
+        - in: query
+          name: alpha_metric
+          description: Filter IDs to those present in the data for `alpha_metric`
+          schema:
+            $ref: '#/components/schemas/alpha_metric'
 
       responses:
         '200':

--- a/microsetta_public_api/api/tests/implementation_tests/test_metadata.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_metadata.py
@@ -1,7 +1,5 @@
 import json
 from unittest.mock import patch, PropertyMock
-from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
-from microsetta_public_api.repo._alpha_repo import AlphaRepo
 from microsetta_public_api.repo._metadata_repo import MetadataRepo
 from microsetta_public_api.utils.testing import MockedJsonifyTestCase
 from microsetta_public_api.api.metadata import (category_values,
@@ -105,10 +103,6 @@ class MetadataImplementationTests(MockedJsonifyTestCase):
         response, code = filter_sample_ids(taxonomy='some-tax')
         self.assertEqual(code, 404)
 
-    def test_metadata_filter_sample_ids_taxonomy_unknown(self):
-        response, code = filter_sample_ids(taxonomy='some-tax')
-        self.assertEqual(code, 404)
-
     def test_metadata_filter_sample_ids_alpha_metric_unknown(self):
         response, code = filter_sample_ids(alpha_metric='some-unknown-metric')
         self.assertEqual(code, 404)
@@ -117,7 +111,7 @@ class MetadataImplementationTests(MockedJsonifyTestCase):
         with patch.object(MetadataRepo, 'sample_id_matches') as mock_matches, \
                 patch('microsetta_public_api.repo._metadata_repo.MetadataRepo.'
                       'categories', new_callable=PropertyMock) as \
-                        mock_categories, \
+                mock_categories, \
                 patch('microsetta_public_api.api.metadata'
                       '.TaxonomyRepo.exists') as mock_exists, \
                 patch('microsetta_public_api.api.metadata.validate_resource'
@@ -136,7 +130,7 @@ class MetadataImplementationTests(MockedJsonifyTestCase):
         with patch.object(MetadataRepo, 'sample_id_matches') as mock_matches, \
                 patch('microsetta_public_api.repo._metadata_repo.MetadataRepo.'
                       'categories', new_callable=PropertyMock) as \
-                        mock_categories, \
+                mock_categories, \
                 patch('microsetta_public_api.api.metadata'
                       '.AlphaRepo.exists') as mock_exists, \
                 patch('microsetta_public_api.api.metadata.validate_resource'

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -186,6 +186,44 @@ class MetadataSampleIdsTests(FlaskTests):
         self.assertCountEqual(obs['sample_ids'], exp_ids)
         self.mock_method.assert_called_with(bmi_cat='normal')
 
+    def test_metadata_sample_ids_get_taxonomy_succeeds(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                    'sample-2',
+                ],
+            })
+
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
+            "/api/metadata/sample-ids?taxonomy=ag-genus")
+        exp_ids = ['sample-1', 'sample-2']
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+        self.mock_method.assert_called_with(taxonomy='ag-genus')
+
+    def test_metadata_sample_ids_get_alpha_metric_succeeds(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                    'sample-2',
+                ],
+            })
+
+        _, self.client = self.build_app_test_client()
+        response = self.client.get(
+            "/api/metadata/sample-ids?alpha_metric=faith_pd")
+        exp_ids = ['sample-1', 'sample-2']
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+        self.mock_method.assert_called_with(alpha_metric='faith_pd')
+
     def test_metadata_sample_ids_get_null_parameters_succeeds(self):
         with self.app_context():
             self.mock_method.return_value = jsonify({

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -226,7 +226,6 @@ class AllIntegrationTest(
 
     def test_metadata_filter_on_taxonomy(self):
         response = self.client.get('/api/metadata/sample-ids?taxonomy=table2')
-        print(response.data)
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample-1', 'sample-2', 'sample-3'],
@@ -235,7 +234,6 @@ class AllIntegrationTest(
     def test_metadata_filter_on_taxonomy_and_age_cat(self):
         response = self.client.get(
             '/api/metadata/sample-ids?taxonomy=table2&age_cat=50s')
-        print(response.data)
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample-3'],
@@ -244,7 +242,6 @@ class AllIntegrationTest(
     def test_metadata_filter_on_alpha_and_age_cat(self):
         response = self.client.get(
             '/api/metadata/sample-ids?alpha_metric=observed_otus&age_cat=50s')
-        print(response.data)
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample-3'],
@@ -254,7 +251,6 @@ class AllIntegrationTest(
         response = self.client.get(
             '/api/metadata/sample-ids?alpha_metric=observed_otus&age_cat=50s'
             '&taxonomy=table2')
-        print(response.data)
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample-3'],
@@ -264,7 +260,6 @@ class AllIntegrationTest(
         response = self.client.get(
             '/api/metadata/sample-ids?alpha_metric=observed_otus&age_cat=30s'
             '&taxonomy=table2')
-        print(response.data)
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertCountEqual([],

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -122,7 +122,7 @@ class MetadataIntegrationTests(IntegrationTests):
         self.assertCountEqual(['sample_ids'], obs.keys())
         self.assertCountEqual(obs['sample_ids'], exp_ids)
 
- 
+
 class TaxonomyIntegrationTests(IntegrationTests):
 
     def setUp(self):


### PR DESCRIPTION
Adds a feature for filtering the sample ids in the metadata by a given table with taxonomy and/or alpha metric data.