### PR TITLE
BUG filter na values from metadata category values

### DIFF
--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -31,11 +31,14 @@ class MetadataIntegrationTests(IntegrationTests):
         self.metadata_path = self.create_tempfile(suffix='.txt').name
         self.metadata_table = pd.DataFrame(
             {
-                'age_cat': ['30s', '40s', '50s', '30s', '30s', '50s'],
-                'bmi_cat': ['normal', 'not', 'not', 'normal', 'not', 'normal'],
-                'num_cat': [20, 30, 7.15, 8.25, 30, 7.15],
+                'age_cat': ['30s', '40s', '50s', '30s', '30s', '50s', '50s'],
+                'bmi_cat': ['normal', 'not', 'not', 'normal', 'not',
+                            'normal', 'overweight'],
+                'num_cat': [20, 30, 7.15, 8.25, 30, 7.15, np.nan],
             }, index=pd.Series(['sample-1', 'sample-2', 'sample-3',
-                                'sample-4', 'sample-5', 'sample-6'],
+                                'sample-4', 'sample-5', 'sample-6',
+                                'sample-7',
+                                ],
                                name='#SampleID')
         )
 
@@ -116,7 +119,7 @@ class MetadataIntegrationTests(IntegrationTests):
         response = self.client.get(
             "/api/metadata/sample-ids")
         exp_ids = ['sample-1', 'sample-2', 'sample-3', 'sample-4',
-                   'sample-5', 'sample-6']
+                   'sample-5', 'sample-6', 'sample-7']
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())

--- a/microsetta_public_api/repo/_metadata_repo.py
+++ b/microsetta_public_api/repo/_metadata_repo.py
@@ -41,12 +41,16 @@ class MetadataRepo:
     def categories(self):
         return list(self._metadata.columns)
 
-    def category_values(self, category):
+    def category_values(self, category, exclude_na=True):
         """
         Parameters
         ----------
         category : str
             Metadata category to return the values of
+
+        exclude_na : bool
+            If True, not a number (na) values will be dropped from the
+            category values
 
         Returns
         -------
@@ -61,8 +65,10 @@ class MetadataRepo:
         """
         if category not in self._metadata.columns:
             raise ValueError(f'No category with name `{category}`')
-        else:
-            return list(self._metadata[category].unique())
+        category_values = self._metadata[category].unique()
+        if exclude_na:
+            category_values = category_values[~pd.isnull(category_values)]
+        return list(category_values)
 
     def sample_id_matches(self, query):
         """


### PR DESCRIPTION
Found this while working with the microsetta metadata.

`NaN` values are not really allowed in JSON format, but python's `json.dump` (exposed via flask) will go ahead and [serialize them anyways](https://stackoverflow.com/questions/6601812/sending-nan-in-json/6601873)... So I added a flag to the metadata repo that allows you to filter them. This was causing problems in javascript when it tried to parse the JSON and got errors on trying to deserialize `Nan`.

The alternative solution was mapping the `NaN` to `None` or some sentinel value, though this PR does not preclude those types of solutions.