### PR TITLE
MAINT Refactor alpha, taxonomy, and metadata for consitstency/convention

### DIFF
--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -63,7 +63,7 @@ paths:
           name: alpha_metric
           description: Filter IDs to those present in the data for `alpha_metric`
           schema:
-            $ref: '#/components/schemas/alpha_metric'
+            $ref: '#/components/schemas/alphaMetric'
 
       responses:
         '200':
@@ -76,7 +76,7 @@ paths:
           $ref: '#/components/responses/404NotFound'
 
 
-  '/diversity/metrics/alpha/available':
+  '/diversity/alpha/metrics/available':
     get:
       operationId: microsetta_public_api.api.diversity.alpha.available_metrics_alpha
       tags:
@@ -96,7 +96,7 @@ paths:
                   alpha_metrics:
                     type: array
                     items:
-                      $ref: '#/components/schemas/alpha_metric'
+                      $ref: '#/components/schemas/alphaMetric'
                     example:
                       - "faith_pd"
                       - "observed_otus"
@@ -110,8 +110,8 @@ paths:
       summary: Get single sample alpha diversity
       description: Get single sample alpha diversity
       parameters:
-        - $ref: '#/components/parameters/sample_id'
-        - $ref: '#/components/parameters/alpha_metric'
+        - $ref: '#/components/parameters/sampleId'
+        - $ref: '#/components/parameters/alphaMetric'
       responses:
         '200':
           description: Successfully return alpha diversity information
@@ -121,9 +121,9 @@ paths:
                 type: object
                 properties:
                   sample_id:
-                    $ref: '#/components/schemas/sample_id'
+                    $ref: '#/components/schemas/sampleId'
                   alpha_metric:
-                    $ref: '#/components/schemas/alpha_metric'
+                    $ref: '#/components/schemas/alphaMetric'
                   data:
                     type: number
                     example: 7.24
@@ -140,7 +140,7 @@ paths:
       description: Query alpha diversity for a group of samples
 
       parameters:
-        - $ref: '#/components/parameters/alpha_metric'
+        - $ref: '#/components/parameters/alphaMetric'
         - in: query
           name: summary_statistics
           schema:
@@ -191,7 +191,7 @@ paths:
                       - alpha_metric
                     properties:
                       alpha_metric:
-                        $ref: '#/components/schemas/alpha_metric'
+                        $ref: '#/components/schemas/alphaMetric'
                   - anyOf:
                     - type: object
                       required:
@@ -324,7 +324,7 @@ paths:
       summary: Get taxonomy information for a sample
       description: Get taxonomy information for a sample
       parameters:
-        - $ref: '#/components/parameters/sample_id'
+        - $ref: '#/components/parameters/sampleId'
         - $ref: '#/components/parameters/taxonomyResource'
 
       responses:
@@ -340,19 +340,19 @@ paths:
 
 components:
   parameters:
-    alpha_metric:
+    alphaMetric:
       name: alpha_metric
       in: path
       description: An alpha diversity metric
       schema:
-        $ref: '#/components/schemas/alpha_metric'
+        $ref: '#/components/schemas/alphaMetric'
       required: true
-    sample_id:
+    sampleId:
       name: sample_id
       in: path
       description: Unique id specifying a sample associated with a source
       schema:
-        $ref: '#/components/schemas/sample_id'
+        $ref: '#/components/schemas/sampleId'
       required: true
     taxonomyResource:
       name: resource
@@ -364,10 +364,10 @@ components:
       required: true
 
   schemas:
-    alpha_metric:
+    alphaMetric:
       type: string
       example: "faith_pd"
-    sample_id:
+    sampleId:
       type: string
       example: "sample_15"
     sampleIdList:
@@ -379,7 +379,7 @@ components:
         sample_ids:
           type: array
           items:
-            $ref: '#/components/schemas/sample_id'
+            $ref: '#/components/schemas/sampleId'
           example:
             - "sample1"
             - "sample2"

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -35,7 +35,7 @@ paths:
         '404':
             $ref: '#/components/responses/404NotFound'
 
-  '/metadata/sample-ids':
+  '/metadata/sample_ids':
     get:
       operationId: microsetta_public_api.api.metadata.filter_sample_ids
       tags:
@@ -289,7 +289,7 @@ paths:
                       - "greengenes"
                       - "silva"
 
-  '/taxonomy/summarize_group/{resource}':
+  '/taxonomy/group/{resource}':
     post:
       operationId: microsetta_public_api.api.taxonomy.summarize_group
       tags:
@@ -316,7 +316,7 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
-  '/taxonomy/single_sample/{resource}/{sample_id}':
+  '/taxonomy/single/{resource}/{sample_id}':
     get:
       operationId: microsetta_public_api.api.taxonomy.single_sample
       tags:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -102,7 +102,7 @@ paths:
                       - "observed_otus"
                       - "chao1"
 
-  '/diversity/alpha/{alpha_metric}/{sample_id}':
+  '/diversity/alpha/single/{alpha_metric}/{sample_id}':
     get:
       operationId: microsetta_public_api.api.diversity.alpha.get_alpha
       tags:
@@ -131,7 +131,7 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
-  '/diversity/alpha_group/{alpha_metric}':
+  '/diversity/alpha/group/{alpha_metric}':
     post:
       operationId: microsetta_public_api.api.diversity.alpha.alpha_group
       tags:

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -328,7 +328,7 @@ class AlphaDiversityTests(AlphaDiversityTestCase):
 
             _, self.client = self.build_app_test_client()
             response = self.client.get(
-                '/api/diversity/alpha/observed_otus/sample-foo-bar')
+                '/api/diversity/alpha/single/observed_otus/sample-foo-bar')
 
             obs = json.loads(response.data)
 
@@ -346,7 +346,7 @@ class AlphaDiversityTests(AlphaDiversityTestCase):
             _, self.client = self.build_app_test_client()
 
             response = self.client.get(
-                '/api/diversity/alpha/observed_otus/sample-foo-bar')
+                '/api/diversity/alpha/single/observed_otus/sample-foo-bar')
 
         self.assertRegex(response.data.decode(),
                          "Sample ID not found.")
@@ -378,7 +378,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         _, self.client = self.build_app_test_client()
 
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus',
+            '/api/diversity/alpha/group/observed_otus',
             content_type='application/json',
             data=json.dumps(self.request_content)
         )
@@ -400,7 +400,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         _, self.client = self.build_app_test_client()
 
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus',
+            '/api/diversity/alpha/group/observed_otus',
             content_type='application/json',
             data=json.dumps(self.request_content)
         )
@@ -421,7 +421,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         _, self.client = self.build_app_test_client()
 
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus',
+            '/api/diversity/alpha/group/observed_otus',
             content_type='application/json',
             data=json.dumps(self.request_content)
         )
@@ -436,7 +436,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         _, self.client = self.build_app_test_client()
 
         self.client.post(
-            '/api/diversity/alpha_group/observed_otus',
+            '/api/diversity/alpha/group/observed_otus',
             content_type='application/json',
             data=json.dumps(self.request_content)
         )
@@ -455,7 +455,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         _, self.client = self.build_app_test_client()
 
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus'
+            '/api/diversity/alpha/group/observed_otus'
             '?summary_statistics=true',
             content_type='application/json',
             data=json.dumps(self.request_content)
@@ -463,7 +463,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         self.assertEqual(response.status_code, 200)
 
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus'
+            '/api/diversity/alpha/group/observed_otus'
             '?summary_statistics=true&percentiles=1,2,45',
             content_type='application/json',
             data=json.dumps(self.request_content)
@@ -471,7 +471,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         self.assertEqual(response.status_code, 200)
 
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus'
+            '/api/diversity/alpha/group/observed_otus'
             '?summary_statistics=false&percentiles=1,2,45',
             content_type='application/json',
             data=json.dumps(self.request_content)
@@ -479,7 +479,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         self.assertEqual(response.status_code, 200)
 
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus'
+            '/api/diversity/alpha/group/observed_otus'
             '?summary_statistics=true&percentiles=0,50,100',
             content_type='application/json',
             data=json.dumps(self.request_content)
@@ -487,7 +487,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         self.assertEqual(response.status_code, 200)
 
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus'
+            '/api/diversity/alpha/group/observed_otus'
             '?percentiles=50',
             content_type='application/json',
             data=json.dumps(self.request_content)
@@ -499,7 +499,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
                 error=400, text='at least one of summary_statistics'
                                 'and return_raw should be true'), 400
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus'
+            '/api/diversity/alpha/group/observed_otus'
             '?summary_statistics=true',
             content_type='application/json',
             data=json.dumps(self.request_content)
@@ -507,7 +507,7 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         self.assertEqual(response.status_code, 400)
 
     def _minimal_query(self):
-        minimal_query = '/api/diversity/alpha_group/observed_otus'
+        minimal_query = '/api/diversity/alpha/group/observed_otus'
         return self.client.post(minimal_query,
                                 content_type='application/json',
                                 data=json.dumps(self.request_content)

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -113,7 +113,7 @@ class MetadataSampleIdsTests(FlaskTests):
         _, self.client = self.build_app_test_client()
         exp_ids = ['sample-1', 'sample-2']
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal")
+            "/api/metadata/sample_ids?age_cat=30s&bmi_cat=normal")
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())
@@ -129,7 +129,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal")
+            "/api/metadata/sample_ids?age_cat=30s&bmi_cat=normal")
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())
@@ -144,7 +144,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal&gimme_cat"
+            "/api/metadata/sample_ids?age_cat=30s&bmi_cat=normal&gimme_cat"
             "=something")
         self.assertStatusCode(404, response)
 
@@ -159,7 +159,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s")
+            "/api/metadata/sample_ids?age_cat=30s")
         exp_ids = ['sample-1', 'sample-2']
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
@@ -178,7 +178,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?bmi_cat=normal")
+            "/api/metadata/sample_ids?bmi_cat=normal")
         exp_ids = ['sample-1', 'sample-2']
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
@@ -197,7 +197,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?taxonomy=ag-genus")
+            "/api/metadata/sample_ids?taxonomy=ag-genus")
         exp_ids = ['sample-1', 'sample-2']
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
@@ -216,7 +216,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids?alpha_metric=faith_pd")
+            "/api/metadata/sample_ids?alpha_metric=faith_pd")
         exp_ids = ['sample-1', 'sample-2']
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
@@ -235,7 +235,7 @@ class MetadataSampleIdsTests(FlaskTests):
 
         _, self.client = self.build_app_test_client()
         response = self.client.get(
-            "/api/metadata/sample-ids")
+            "/api/metadata/sample_ids")
         exp_ids = ['sample-1', 'sample-2']
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
@@ -638,7 +638,7 @@ class TaxonomyGroupAPITests(FlaskTests):
                 }
             ), 200
 
-        response = self.client.post('/api/taxonomy/summarize_group/greengenes',
+        response = self.client.post('/api/taxonomy/group/greengenes',
                                     content_type='application/json',
                                     data=json.dumps(self.request_content))
         self.assertEqual(200, response.status_code)
@@ -668,6 +668,6 @@ class TaxonomySingleSampleAPITests(FlaskTests):
             ), 200
 
         response = self.client.get(
-            '/api/taxonomy/single_sample/greengenes/sample-1',
+            '/api/taxonomy/single/greengenes/sample-1',
         )
         self.assertEqual(200, response.status_code)

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -271,7 +271,7 @@ class AlphaDiversityTests(AlphaDiversityTestCase):
 
             exp_metrics = ['faith_pd', 'chao1']
             response = self.client.get(
-                '/api/diversity/metrics/alpha/available')
+                '/api/diversity/alpha/metrics/available')
 
             obs = json.loads(response.data)
             self.assertIn('alpha_metrics', obs)
@@ -282,7 +282,7 @@ class AlphaDiversityTests(AlphaDiversityTestCase):
                 'alpha_metrics': []
             }), 200
             response = self.client.get(
-                '/api/diversity/metrics/alpha/available')
+                '/api/diversity/alpha/metrics/available')
 
             obs = json.loads(response.data)
             self.assertIn('alpha_metrics', obs)
@@ -300,7 +300,7 @@ class AlphaDiversityTests(AlphaDiversityTestCase):
             _, self.client = self.build_app_test_client()
 
             response = self.client.get(
-                '/api/diversity/metrics/alpha/available')
+                '/api/diversity/alpha/metrics/available')
 
             self.assertEqual(response.status_code, 500)
             mock_resources.return_value = jsonify({

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -300,7 +300,7 @@ class AlphaIntegrationTests(IntegrationTests):
         resources.update(config.resources)
 
     def test_resources_available(self):
-        response = self.client.get('/api/diversity/metrics/alpha/available')
+        response = self.client.get('/api/diversity/alpha/metrics/available')
 
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -309,7 +309,7 @@ class AlphaIntegrationTests(IntegrationTests):
 
     def test_group_summary(self):
         response = self.client.post(
-            '/api/diversity/alpha_group/observed_otus'
+            '/api/diversity/alpha/group/observed_otus'
             '?summary_statistics=true&percentiles=0,50,100&return_raw=true',
             content_type='application/json',
             data=json.dumps({'sample_ids': ['sample-foo-bar',

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -69,7 +69,7 @@ class MetadataIntegrationTests(IntegrationTests):
     def test_metadata_sample_ids_returns_simple(self):
         exp_ids = ['sample-1', 'sample-4']
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal")
+            "/api/metadata/sample_ids?age_cat=30s&bmi_cat=normal")
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())
@@ -77,7 +77,7 @@ class MetadataIntegrationTests(IntegrationTests):
 
     def test_metadata_sample_ids_returns_empty(self):
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=20s&bmi_cat=normal")
+            "/api/metadata/sample_ids?age_cat=20s&bmi_cat=normal")
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())
@@ -88,7 +88,7 @@ class MetadataIntegrationTests(IntegrationTests):
         # num_cat is not configured to be able to be queried on, so this
         #  tests to make sure it is ignored
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s&bmi_cat=normal&num_cat=30")
+            "/api/metadata/sample_ids?age_cat=30s&bmi_cat=normal&num_cat=30")
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())
@@ -96,7 +96,7 @@ class MetadataIntegrationTests(IntegrationTests):
 
     def test_metadata_sample_ids_get_age_cat_only(self):
         response = self.client.get(
-            "/api/metadata/sample-ids?age_cat=30s")
+            "/api/metadata/sample_ids?age_cat=30s")
         exp_ids = ['sample-1', 'sample-4', 'sample-5']
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
@@ -105,7 +105,7 @@ class MetadataIntegrationTests(IntegrationTests):
 
     def test_metadata_sample_ids_get_bmi_only(self):
         response = self.client.get(
-            "/api/metadata/sample-ids?bmi_cat=normal")
+            "/api/metadata/sample_ids?bmi_cat=normal")
         exp_ids = ['sample-1', 'sample-4', 'sample-6']
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
@@ -114,7 +114,7 @@ class MetadataIntegrationTests(IntegrationTests):
 
     def test_metadata_sample_ids_get_null_parameters_succeeds(self):
         response = self.client.get(
-            "/api/metadata/sample-ids")
+            "/api/metadata/sample_ids")
         exp_ids = ['sample-1', 'sample-2', 'sample-3', 'sample-4',
                    'sample-5', 'sample-6']
         self.assertStatusCode(200, response)
@@ -221,7 +221,7 @@ class TaxonomyIntegrationTests(IntegrationTests):
         self.assertCountEqual(['table2', 'table-fish'], obs['resources'])
 
     def test_summarize_group(self):
-        response = self.client.post('/api/taxonomy/summarize_group/table2',
+        response = self.client.post('/api/taxonomy/group/table2',
                                     content_type='application/json',
                                     data=json.dumps({'sample_ids': [
                                         'sample-1']}))
@@ -246,7 +246,7 @@ class TaxonomyIntegrationTests(IntegrationTests):
 
     def test_summarize_single_sample(self):
         response = self.client.get(
-            '/api/taxonomy/single_sample/table2/sample-1',
+            '/api/taxonomy/single/table2/sample-1',
         )
 
         self.assertEqual(response.status_code, 200)
@@ -338,7 +338,7 @@ class AllIntegrationTest(
         ):
 
     def test_metadata_filter_on_taxonomy(self):
-        response = self.client.get('/api/metadata/sample-ids?taxonomy=table2')
+        response = self.client.get('/api/metadata/sample_ids?taxonomy=table2')
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample-1', 'sample-2', 'sample-3'],
@@ -346,7 +346,7 @@ class AllIntegrationTest(
 
     def test_metadata_filter_on_taxonomy_and_age_cat(self):
         response = self.client.get(
-            '/api/metadata/sample-ids?taxonomy=table2&age_cat=50s')
+            '/api/metadata/sample_ids?taxonomy=table2&age_cat=50s')
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample-3'],
@@ -354,7 +354,7 @@ class AllIntegrationTest(
 
     def test_metadata_filter_on_alpha_and_age_cat(self):
         response = self.client.get(
-            '/api/metadata/sample-ids?alpha_metric=observed_otus&age_cat=50s')
+            '/api/metadata/sample_ids?alpha_metric=observed_otus&age_cat=50s')
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample-3'],
@@ -362,7 +362,7 @@ class AllIntegrationTest(
 
     def test_metadata_filter_on_alpha_and_and_taxonomy_and_age_cat(self):
         response = self.client.get(
-            '/api/metadata/sample-ids?alpha_metric=observed_otus&age_cat=50s'
+            '/api/metadata/sample_ids?alpha_metric=observed_otus&age_cat=50s'
             '&taxonomy=table2')
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
@@ -371,7 +371,7 @@ class AllIntegrationTest(
 
     def test_metadata_filter_on_alpha_and_and_taxonomy_and_age_cat_empty(self):
         response = self.client.get(
-            '/api/metadata/sample-ids?alpha_metric=observed_otus&age_cat=30s'
+            '/api/metadata/sample_ids?alpha_metric=observed_otus&age_cat=30s'
             '&taxonomy=table2')
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)


### PR DESCRIPTION
This PR serves to unify to provide a more consistent interface with the API. This entails the following path changes:

- [x] `/diversity/metrics/alpha/available` -> `/diversity/alpha/metrics/available`

- [x] `/diversity/alpha/{alpha_metric}/{sample_id}` -> `/diversity/alpha/single/{alpha_metric}/{sample_id}`

- [x] `/diversity/alpha_group/{alpha_metric}` -> `/diversity/alpha/group/{alpha_metric}`

- [x] `/taxonomy/summarize_group/{resource}` -> `/taxonomy/group/{resource}`

- [x] `/taxonomy/single_sample/{resource}/{sample_id}` -> `/taxonomy/single/{resource}/{sample_id}`

- [x] `/metadata/sample-ids` -> `/metadata/sample_ids`

And the following refactoring of snake case to camel case in the swagger schemas, to reflect more typical swagger convention for schemas:
- [x] `alpha_metric` -> `alphaMetric`

- [x] `sample_id` -> `sampleId`