### PR TITLE
Fix metadata 500 error

### DIFF
--- a/microsetta_public_api/api/metadata.py
+++ b/microsetta_public_api/api/metadata.py
@@ -32,7 +32,7 @@ def filter_sample_ids(taxonomy=None, alpha_metric=None, **kwargs):
     )
 
     if error_response:
-        return jsonify(*error_response), error_code
+        return error_response, error_code
 
     return jsonify(sample_ids=matching_ids), 200
 

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -125,6 +125,28 @@ class MetadataIntegrationTests(IntegrationTests):
         self.assertCountEqual(['sample_ids'], obs.keys())
         self.assertCountEqual(obs['sample_ids'], exp_ids)
 
+    def test_metadata_filter_on_metric_dne(self):
+        response = self.client.get(
+            # careful not to use a metric that exists in AlphaIntegrationTests
+            '/api/metadata/sample_ids?alpha_metric=bad-metric')
+        self.assertEqual(response.status_code, 404)
+
+    def test_metadata_filter_on_taxonomy_dne(self):
+        response = self.client.get(
+            # careful not to use a table that exists in
+            #  TaxonomyIntegrationTests
+            '/api/metadata/sample_ids?alpha_metric=bad-table')
+        self.assertEqual(response.status_code, 404)
+
+    def test_metadata_filter_on_metric_and_taxonomy_dne(self):
+        response = self.client.get(
+            # careful not to use a metric that exists in AlphaIntegrationTests
+            # careful not to use a table that exists in
+            #  TaxonomyIntegrationTests
+            '/api/metadata/sample_ids?alpha_metric=bad-metric&taxonomy=bad'
+            '-table')
+        self.assertEqual(response.status_code, 404)
+
 
 class TaxonomyIntegrationTests(IntegrationTests):
 
@@ -161,7 +183,6 @@ class TaxonomyIntegrationTests(IntegrationTests):
                                           ['feature-3', 'a; f; g; h', 0.678]],
                                          columns=['Feature ID', 'Taxon',
                                                   'Confidence'])
-
         self.taxonomy2_df.set_index('Feature ID', inplace=True)
 
         self.table3 = biom.Table(np.array([[1, 2],


### PR DESCRIPTION
Fixes #25 .

I was able to identify bad `alpha_metric` and `taxonomy` values in `"GET /api/metadata/sample_ids"` as a source of this bug. When the values did not exist on the server, `flask.jsonify` would be called on a `flask.Response` object, causing this error.

This PR adds tests that expose the bug and a fix.

It was not observed in the previous implementation tests, presumably due to differences between `flask`'s `Response` object and my `MockedResponse`, which is used in the metadata implementation unit tests. Integration tests helped resolve this discrepancy.