### PR TITLE
Cache taxonomy model (optional, defaults to true, recommended for large datasets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ feature data. Tables can either be QZA `FeatureTable`'s or biom tables. If a `bi
 the `"table-format": "biom"` option must be specified. Taxonomy data is accepted with the
 `"feature-data-taxonomy"` keyword, which should correspond to the filepath to a QIIME2 `FeatureData[Taxonomy]`.
 
+For large datasets, creating a Taxonomy model can be slow. You can cache the model on server startup by adding the
+`"cache-taxonomy": true` keyword to your specific table. This should speed up the time for API calls.
+
 ### Metadata
 The server can be configured to contain metadata, by adding a  `"metadata"` keyword to the config,
 that gives a path to a QIIME2 formatted metadata file.
@@ -66,7 +69,8 @@ that gives a path to a QIIME2 formatted metadata file.
     "taxonomy": {
       "table": "/path/to/table.biom",
       "table-format": "biom",
-      "feature-data-taxonomy": "/path/to/a/taxonomy-data.qza"
+      "feature-data-taxonomy": "/path/to/a/taxonomy-data.qza",
+      "cache-model": true
     }
   },
   "metadata": "/path/to/some/metadata.txt"

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -1,6 +1,5 @@
 from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
 from microsetta_public_api.utils import jsonify
-from microsetta_public_api.models._taxonomy import Taxonomy
 from microsetta_public_api.utils._utils import (validate_resource,
                                                 check_missing_ids,
                                                 )
@@ -33,11 +32,8 @@ def _summarize_group(sample_ids, table_name):
     if missing_ids_msg:
         return missing_ids_msg
 
-    table = taxonomy_repo.table(table_name)
-    features = taxonomy_repo.feature_data_taxonomy(table_name)
-    variances = taxonomy_repo.variances(table_name)
+    taxonomy_ = taxonomy_repo.model(table_name)
 
-    taxonomy_ = Taxonomy(table, features, variances)
     taxonomy_data = taxonomy_.get_group(sample_ids, '').to_dict()
     del taxonomy_data['name']
     del taxonomy_data['feature_ranks']

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -211,6 +211,11 @@ class TaxonomyIntegrationTests(IntegrationTests):
                 'table': self.table_biom,
                 'table-format': 'biom',
             },
+            'table-cached-model': {
+                'table': self.table1_filename,
+                'feature-data-taxonomy': self.taxonomy1_filename,
+                'cache-taxonomy': True,
+            },
         }})
         resources.update(config.resources)
 
@@ -221,10 +226,35 @@ class TaxonomyIntegrationTests(IntegrationTests):
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertIn('resources', obs)
-        self.assertCountEqual(['table2', 'table-fish'], obs['resources'])
+        self.assertCountEqual(['table2', 'table-fish', 'table-cached-model'],
+                              obs['resources'])
 
     def test_summarize_group(self):
         response = self.client.post('/api/taxonomy/group/table2',
+                                    content_type='application/json',
+                                    data=json.dumps({'sample_ids': [
+                                        'sample-1']}))
+
+        self.assertEqual(response.status_code, 200)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['taxonomy', 'features',
+                               'feature_values', 'feature_variances'],
+                              obs.keys())
+
+        self.assertEqual('((((((feature-2)e)d)c)b,(((feature-3)h)g)f)a);',
+                         obs['taxonomy']
+                         )
+        self.assertListEqual(['feature-2', 'feature-3'],
+                             obs['features'])
+        assert_allclose([2. / 5, 3. / 5],
+                        obs['feature_values']
+                        )
+        assert_allclose([0, 0],
+                        obs['feature_variances']
+                        )
+
+    def test_summarize_group_cached_model(self):
+        response = self.client.post('/api/taxonomy/group/table-cached-model',
                                     content_type='application/json',
                                     data=json.dumps({'sample_ids': [
                                         'sample-1']}))

--- a/microsetta_public_api/repo/_taxonomy_repo.py
+++ b/microsetta_public_api/repo/_taxonomy_repo.py
@@ -1,4 +1,5 @@
 from microsetta_public_api.resources import resources
+from microsetta_public_api.models._taxonomy import Taxonomy as TaxonomyModel
 
 
 class TaxonomyRepo:
@@ -58,6 +59,15 @@ class TaxonomyRepo:
 
     def variances(self, table_name):
         return self._get_resource(table_name, component='variances')
+
+    def model(self, table_name):
+        model = self._get_resource(table_name, component='model')
+        if model is None:
+            table = self.table(table_name)
+            features = self.feature_data_taxonomy(table_name)
+            variances = self.variances(table_name)
+            model = TaxonomyModel(table, features, variances)
+        return model
 
     def exists(self, sample_ids, table_name):
         """Checks if sample_ids exist for the given table.

--- a/microsetta_public_api/repo/tests/test_taxonomy_repo.py
+++ b/microsetta_public_api/repo/tests/test_taxonomy_repo.py
@@ -114,15 +114,18 @@ class TestTaxonomyRepoWithResources(TempfileTestCase, ConfigTestCase):
             'table2': {
                 'table': self.table1_filename,
                 'feature-data-taxonomy': self.taxonomy1_filename,
+                'cache-taxonomy': False,
             },
             'table3': {
                 'table': self.table3_filename,
                 'feature-data-taxonomy': self.taxonomy2_filename,
+                'cache-taxonomy': False,
                 'variances': self.table3_filename,
             },
             'table4': {
                 'table': self.table_biom,
                 'feature-data-taxonomy': self.taxonomy1_filename,
+                'cache-taxonomy': False,
                 'table-format': 'biom'
             },
             'table5': {

--- a/microsetta_public_api/repo/tests/test_taxonomy_repo.py
+++ b/microsetta_public_api/repo/tests/test_taxonomy_repo.py
@@ -12,6 +12,7 @@ from microsetta_public_api.resources import resources
 from microsetta_public_api.utils.testing import (TempfileTestCase,
                                                  ConfigTestCase)
 from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
+from microsetta_public_api.models._taxonomy import Taxonomy as TaxonomyModel
 
 
 class TestTaxonomyRepoHelpers(TestCase):
@@ -131,6 +132,11 @@ class TestTaxonomyRepoWithResources(TempfileTestCase, ConfigTestCase):
                 'table': self.table_biom,
                 'table-format': 'biom',
             },
+            'cached-taxonomy-table': {
+                'table': self.table1_filename,
+                'feature-data-taxonomy': self.taxonomy1_filename,
+                'cache-taxonomy': True,
+            },
         }})
         resources.update(config.resources)
         self.repo = TaxonomyRepo()
@@ -140,7 +146,7 @@ class TestTaxonomyRepoWithResources(TempfileTestCase, ConfigTestCase):
         ConfigTestCase.tearDown(self)
 
     def test_available_taxonomy_tables(self):
-        exp = ['table2', 'table3', 'table4']
+        exp = ['table2', 'table3', 'table4', 'cached-taxonomy-table']
         obs = self.repo.resources()
         self.assertCountEqual(exp, obs)
 
@@ -154,6 +160,11 @@ class TestTaxonomyRepoWithResources(TempfileTestCase, ConfigTestCase):
         obs = self.repo.table('table2')
         self.assertEqual(exp, obs)
 
+    def test_get_table_cached_taxonomy(self):
+        exp = self.table
+        obs = self.repo.table('cached-taxonomy-table')
+        self.assertEqual(exp, obs)
+
     def test_get_table_invalid(self):
         with self.assertRaises(ValueError):
             self.repo.table('table1')
@@ -163,6 +174,16 @@ class TestTaxonomyRepoWithResources(TempfileTestCase, ConfigTestCase):
         obs = self.repo.feature_data_taxonomy('table4')
         obs['Confidence'] = obs['Confidence'].astype('float64')
         assert_frame_equal(exp, obs)
+
+    def test_get_taxonomy_model_cached(self):
+        exp = resources['table_resources']['cached-taxonomy-table']['model']
+        obs = self.repo.model('cached-taxonomy-table')
+        self.assertIs(exp, obs)
+
+    def test_get_taxonomy_model_non_cached(self):
+        self.assertNotIn('model', resources['table_resources']['table2'])
+        obs = self.repo.model('table2')
+        self.assertIsInstance(obs, TaxonomyModel)
 
     def test_get_taxonomy_invalid(self):
         with self.assertRaises(ValueError):

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -88,7 +88,7 @@ def _transform_single_table(dict_, resource_name):
         elif key in biom_kws:
             new_resource[key] = biom.load_table(value)
 
-    cache_taxonomy = new_resource.get('cache-taxonomy', False)
+    cache_taxonomy = new_resource.get('cache-taxonomy', True)
     if 'feature-data-taxonomy' in new_resource and cache_taxonomy:
         table = new_resource['table']
         taxonomy = new_resource['feature-data-taxonomy']

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -10,6 +10,8 @@ from q2_types.sample_data import AlphaDiversity, SampleData
 from q2_types.feature_table import FeatureTable, Frequency
 from q2_types.feature_data import FeatureData, Taxonomy
 
+from microsetta_public_api.models._taxonomy import Taxonomy as TaxonomyModel
+
 
 def _dict_of_paths_to_alpha_data(dict_of_qza_paths, resource_name):
     _validate_dict_of_paths(dict_of_qza_paths,
@@ -42,7 +44,8 @@ def _transform_single_table(dict_, resource_name):
 
     _validate_dict_of_paths(dict_, resource_name, allow_none=True,
                             required_fields=['table'],
-                            non_ext_entries=['q2-type', 'table-format'],
+                            non_ext_entries=['q2-type', 'table-format',
+                                             'cache-taxonomy'],
                             allow_extras=True,
                             extensions=['.' + table_type]
                             )
@@ -84,6 +87,14 @@ def _transform_single_table(dict_, resource_name):
                                                )
         elif key in biom_kws:
             new_resource[key] = biom.load_table(value)
+
+    cache_taxonomy = new_resource.get('cache-taxonomy', False)
+    if 'feature-data-taxonomy' in new_resource and cache_taxonomy:
+        table = new_resource['table']
+        taxonomy = new_resource['feature-data-taxonomy']
+        variances = new_resource.get('variances', None)
+        model = TaxonomyModel(table, taxonomy, variances)
+        new_resource['model'] = model
 
     return new_resource
 

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -296,7 +296,7 @@ class TestResourceManagerUpdateTables(TempfileTestCase):
                              [subset_table])
         new_table_config = self.resources['table_resources'][
             subset_table]
-        self.assertCountEqual(['table', 'feature-data-taxonomy'],
+        self.assertCountEqual(['table', 'feature-data-taxonomy', 'model'],
                               new_table_config.keys())
 
         exp_table = self.table
@@ -339,7 +339,8 @@ class TestResourceManagerUpdateTables(TempfileTestCase):
                              [subset_table])
         new_table_config = self.resources['table_resources'][
             subset_table]
-        self.assertCountEqual(['table', 'variances', 'feature-data-taxonomy'],
+        self.assertCountEqual(['table', 'variances',
+                               'feature-data-taxonomy', 'model'],
                               new_table_config.keys())
 
         exp_table = self.table


### PR DESCRIPTION
Fixes #26 

This PR adds a `cache-taxonomy` keyword to the server config, which can be used to create the model a single time on server start (or subsequent update of the resources).

The default value is currently false, unless otherwise specified.