### PR TITLE
UTIL adds a utility class for a randomizable test database

### DIFF
--- a/microsetta_public_api/server.py
+++ b/microsetta_public_api/server.py
@@ -29,12 +29,13 @@ def build_app(resources_config_json=None):
 if __name__ == "__main__":
     import sys
     config_fp = sys.argv[1] if len(sys.argv) > 1 else None
+    PORT = 8084
     if config_fp:
         app = build_app(resources_config_json=config_fp)
-        app.run(port=8083, debug=True)
+        app.run(port=PORT, debug=True)
     else:
         # import TestDatabase here to avoid circular import
         from microsetta_public_api.utils.testing import TestDatabase
         with TestDatabase():
             app = build_app()
-            app.run(port=8083, debug=True)
+            app.run(port=PORT, debug=True)

--- a/microsetta_public_api/server.py
+++ b/microsetta_public_api/server.py
@@ -38,4 +38,3 @@ if __name__ == "__main__":
         with TestDatabase():
             app = build_app()
             app.run(port=8083, debug=True)
-

--- a/microsetta_public_api/server.py
+++ b/microsetta_public_api/server.py
@@ -29,5 +29,13 @@ def build_app(resources_config_json=None):
 if __name__ == "__main__":
     import sys
     config_fp = sys.argv[1] if len(sys.argv) > 1 else None
-    app = build_app(resources_config_json=config_fp)
-    app.run(port=8083, debug=True)
+    if config_fp:
+        app = build_app(resources_config_json=config_fp)
+        app.run(port=8083, debug=True)
+    else:
+        # import TestDatabase here to avoid circular import
+        from microsetta_public_api.utils.testing import TestDatabase
+        with TestDatabase():
+            app = build_app()
+            app.run(port=8083, debug=True)
+

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -145,7 +145,7 @@ class ConfigTestCase(TestCase):
 class TestDatabase:
     def __init__(self, n_samples=2000, seed=None):
         np.random.seed(seed)
-        sample_set = [f'sample-{i + 1}' for i in range(n_samples)]
+        sample_set = [f'sample-{i + 1:04d}' for i in range(n_samples)]
         age_categories = np.array(['30s', '40s', '50s'])
         bmi_categories = np.array(['Normal', 'Overweight', 'Underweight'])
 

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -149,7 +149,7 @@ class TestDatabase:
         bmi_categories = np.array(['Normal', 'Overweight', 'Underweight'])
 
         self.faith_pd_data = pd.Series(np.random.normal(6, 1.5, n_samples),
-                                  index=sample_set, name='faith_pd')
+                                       index=sample_set, name='faith_pd')
 
         self.metadata_table = pd.DataFrame(
             {

--- a/microsetta_public_api/utils/tests/test_utils.py
+++ b/microsetta_public_api/utils/tests/test_utils.py
@@ -20,6 +20,8 @@ class TestDatabaseTests(TestCase):
         with TestDatabase():
             self.assertIn('metadata', resources)
             self.assertIn('alpha_resources', resources)
+            self.assertIn('table_resources', resources)
 
         self.assertNotIn('metadata', resources)
         self.assertNotIn('alpha_resources', resources)
+        self.assertNotIn('table_resources', resources)

--- a/microsetta_public_api/utils/tests/test_utils.py
+++ b/microsetta_public_api/utils/tests/test_utils.py
@@ -1,6 +1,7 @@
 from unittest.case import TestCase
 
-from microsetta_public_api.utils.testing import mocked_jsonify
+from microsetta_public_api.utils.testing import mocked_jsonify, TestDatabase
+from microsetta_public_api.resources import resources
 
 
 class MockedJsonifyTests(TestCase):
@@ -11,3 +12,14 @@ class MockedJsonifyTests(TestCase):
         mocked_jsonify('a', 'b', 'c')
         with self.assertRaises(TypeError):
             mocked_jsonify({'a': 'b', 'c': 'd'}, e='f')
+
+
+class TestDatabaseTests(TestCase):
+
+    def test_basic_test_db(self):
+        with TestDatabase():
+            self.assertIn('metadata', resources)
+            self.assertIn('alpha_resources', resources)
+
+        self.assertNotIn('metadata', resources)
+        self.assertNotIn('alpha_resources', resources)


### PR DESCRIPTION
Adds a utility for creating test databases on the fly. This could be used to create a database of arbitrary size, for stress-testing, or other similar purposes.