### PR TITLE
API add datatable compatible endpoint for taxonomy

### DIFF
--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -416,6 +416,10 @@ components:
     alphaMetric:
       type: string
       example: "faith_pd"
+    relativeAbundance:
+      type: number
+      minimum: 0
+      maximum: 1
     sampleId:
       type: string
       example: "sample_15"
@@ -448,31 +452,38 @@ components:
             properties:
               sampleId:
                 $ref: '#/components/schemas/sampleId'
+              relativeAbundance:
+                $ref: '#/components/schemas/relativeAbundance'
             example:
               - {
                   "sampleId": "sample1",
                   "Kingdom": "Bacteria",
-                  "Genus": "Bacteroides"
+                  "Genus": "Bacteroides",
+                  "relativeAbundance": 0.2
                 }
               - {
                   "sampleId": "sample1",
                   "Kingdom": "Bacteria",
-                  "Genus": "Clostridium"
+                  "Genus": "Clostridium",
+                  "relativeAbundance": 0.8
                 }
               - {
                   "sampleId": "sample2",
                   "Kingdom": "Bacteria",
-                  "Genus": "Bacteroides"
+                  "Genus": "Bacteroides",
+                  "relativeAbundance": 0.72
                 }
               - {
                   "sampleId": "sample2",
                   "Kingdom": "Bacteria",
-                  "Genus": null
+                  "Genus": null,
+                  "relativeAbundance": 0.28
                 }
               - {
                   "sampleId": "sample3",
                   "Kingdom": "Bacteria",
-                  "Genus": "Clostridium"
+                  "Genus": "Clostridium",
+                  "relativeAbundance": 1.0
                 }
         columns:
           type: array
@@ -487,6 +498,7 @@ components:
                   - "sampleId"
                   - "Kingdom"
                   - "Genus"
+                  - "relativeAbundance"
     taxonomyFeatures:
       type: object
       required:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -338,6 +338,55 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+  '/taxonomy/present/group/{resource}':
+    post:
+      operationId: microsetta_public_api.api.taxonomy.group_taxa_present
+      tags:
+        - Taxonomy
+      summary: Get a DataTable of taxa, broken down by rank, for a list of samples
+      description: Get a DataTable of taxa, broken down by rank, for a list of samples
+      parameters:
+        - $ref: '#/components/parameters/taxonomyResource'
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/sampleIdList"
+
+      responses:
+        '200':
+          description: Successfully return taxonomy table
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sampleDataTable'
+
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
+  '/taxonomy/present/single/{resource}/{sample_id}':
+    get:
+      operationId: microsetta_public_api.api.taxonomy.single_sample_taxa_present
+      tags:
+        - Taxonomy
+      summary: Get a DataTable of taxa, broken down by rank, for a given sample
+      description: Get a DataTable of taxa, broken down by rank, for a given sample
+      parameters:
+        - $ref: '#/components/parameters/sampleId'
+        - $ref: '#/components/parameters/taxonomyResource'
+
+      responses:
+        '200':
+          description: Successfully return taxonomy table
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sampleDataTable'
+
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
 components:
   parameters:
     alphaMetric:
@@ -374,7 +423,7 @@ components:
       type: object
       required:
         - sample_ids
-      additionalProperties: False
+      additionalProperties: false
       properties:
         sample_ids:
           type: array
@@ -384,6 +433,60 @@ components:
             - "sample1"
             - "sample2"
             - "sample3"
+    sampleDataTable:
+      type: object
+      required:
+        - data
+        - columns
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            required:
+              - sampleId
+            properties:
+              sampleId:
+                $ref: '#/components/schemas/sampleId'
+            example:
+              - {
+                  "sampleId": "sample1",
+                  "Kingdom": "Bacteria",
+                  "Genus": "Bacteroides"
+                }
+              - {
+                  "sampleId": "sample1",
+                  "Kingdom": "Bacteria",
+                  "Genus": "Clostridium"
+                }
+              - {
+                  "sampleId": "sample2",
+                  "Kingdom": "Bacteria",
+                  "Genus": "Bacteroides"
+                }
+              - {
+                  "sampleId": "sample2",
+                  "Kingdom": "Bacteria",
+                  "Genus": null
+                }
+              - {
+                  "sampleId": "sample3",
+                  "Kingdom": "Bacteria",
+                  "Genus": "Clostridium"
+                }
+        columns:
+          type: array
+          items:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: string
+                example:
+                  - "sampleId"
+                  - "Kingdom"
+                  - "Genus"
     taxonomyFeatures:
       type: object
       required:

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -51,3 +51,11 @@ def resources():
         'resources': taxonomy_repo.resources(),
     }
     return jsonify(ret_val), 200
+
+
+def single_sample_taxa_present(sample_id, resource):
+    raise NotImplementedError()
+
+
+def group_taxa_present(body, resource):
+    raise NotImplementedError()

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -682,33 +682,39 @@ class TaxonomyDataTableTests(FlaskTests):
             {
                 "sampleId": "sample1",
                 "Kingdom": "Bacteria",
-                "Genus": "Bacteroides"
+                "Genus": "Bacteroides",
+                "relativeAbundance": 0.7,
             },
             {
                 "sampleId": "sample1",
                 "Kingdom": "Bacteria",
-                "Genus": "Clostridium"
+                "Genus": "Clostridium",
+                "relativeAbundance": 0.3,
             },
             {
                 "sampleId": "sample2",
                 "Kingdom": "Bacteria",
-                "Genus": "Bacteroides"
+                "Genus": "Bacteroides",
+                "relativeAbundance": 0.2,
             },
             {
                 "sampleId": "sample2",
                 "Kingdom": "Bacteria",
-                "Genus": None
+                "Genus": None,
+                "relativeAbundance": 0.8,
             },
             {
                 "sampleId": "sample3",
                 "Kingdom": "Bacteria",
-                "Genus": "Clostridium"
+                "Genus": "Clostridium",
+                "relativeAbundance": 1.0,
             },
         ],
             'columns': [
             {'data': 'sampleId'},
             {'data': 'Kingdom'},
             {'data': 'Genus'},
+            {'data': 'relativeAbundance'}
         ]}
 
     def setUp(self):


### PR DESCRIPTION
Adds an endpoint (no implementation) for a taxonomy summary that should be more compatible with the jQuery DataTable as detailed [here](https://datatables.net/reference/option/columns.data). As mentioned in #27 