### PR TITLE
Jquery datable compatible taxonomy endpoint implementation

### DIFF
--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -57,19 +57,22 @@ def resources():
 
 def single_sample_taxa_present(sample_id, resource):
     sample_ids = [sample_id]
-    return _presence_absence_table(sample_ids, resource)
+    return _present_microbes_taxonomy_table(sample_ids, resource)
 
 
 def group_taxa_present(body, resource):
     sample_ids = body['sample_ids']
-    return _presence_absence_table(sample_ids, resource)
+    return _present_microbes_taxonomy_table(sample_ids, resource)
 
 
-def _presence_absence_table(sample_ids, resource):
+def _present_microbes_taxonomy_table(sample_ids, resource):
     taxonomy_repo = TaxonomyRepo()
     error_response = _check_resource_and_missing_ids(taxonomy_repo,
                                                      sample_ids, resource)
     if error_response:
         return error_response
 
-    raise NotImplementedError()
+    taxonomy_ = taxonomy_repo.model(resource)
+    taxonomy_table = taxonomy_.presence_data_table(sample_ids)
+    response = jsonify(taxonomy_table.to_dict())
+    return response, 200

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -16,23 +16,29 @@ def summarize_group(body, resource):
     return _summarize_group(sample_ids, resource)
 
 
-def _summarize_group(sample_ids, table_name):
-    taxonomy_repo = TaxonomyRepo()
+def _check_resource_and_missing_ids(taxonomy_repo, sample_ids, resource):
     available_resources = taxonomy_repo.resources()
 
     type_ = 'resource'
-    missing_resource = validate_resource(available_resources, table_name,
+    missing_resource = validate_resource(available_resources, resource,
                                          type_)
     if missing_resource:
         return missing_resource
 
     missing_ids = [id_ for id_ in sample_ids if
-                   not taxonomy_repo.exists(id_, table_name)]
+                   not taxonomy_repo.exists(id_, resource)]
 
-    missing_ids_msg = check_missing_ids(missing_ids, table_name, type_)
+    missing_ids_msg = check_missing_ids(missing_ids, resource, type_)
     if missing_ids_msg:
         return missing_ids_msg
 
+
+def _summarize_group(sample_ids, table_name):
+    taxonomy_repo = TaxonomyRepo()
+    error_response = _check_resource_and_missing_ids(taxonomy_repo,
+                                                     sample_ids, table_name)
+    if error_response:
+        return error_response
     table = taxonomy_repo.table(table_name)
     features = taxonomy_repo.feature_data_taxonomy(table_name)
     variances = taxonomy_repo.variances(table_name)
@@ -51,3 +57,23 @@ def resources():
         'resources': taxonomy_repo.resources(),
     }
     return jsonify(ret_val), 200
+
+
+def single_sample_taxa_present(sample_id, resource):
+    sample_ids = [sample_id]
+    return _presence_absence_table(sample_ids, resource)
+
+
+def group_taxa_present(body, resource):
+    sample_ids = body['sample_ids']
+    return _presence_absence_table(sample_ids, resource)
+
+
+def _presence_absence_table(sample_ids, resource):
+    taxonomy_repo = TaxonomyRepo()
+    error_response = _check_resource_and_missing_ids(taxonomy_repo,
+                                                     sample_ids, resource)
+    if error_response:
+        return error_response
+
+    raise NotImplementedError()

--- a/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
@@ -494,7 +494,9 @@ class TaxonomyTaxaPresentDataTableImplementationTests(MockedJsonifyTestCase):
         obs = json.loads(response)
         print(obs)
         self.assertCountEqual(exp_keys, obs.keys())
-        self.assertCountEqual(obs['columns'], ['sampleId', 'rank_1', 'rank_2'])
+        self.assertCountEqual(obs['columns'], [{'data': 'sampleId'},
+                                               {'data': 'rank_1'},
+                                               {'data': 'rank_2'}])
         for item in obs['data']:
             self.assertCountEqual(item.keys(), ['sampleId', 'rank_1',
                                                 'rank_2'])
@@ -527,7 +529,9 @@ class TaxonomyTaxaPresentDataTableImplementationTests(MockedJsonifyTestCase):
         obs = json.loads(response)
         print(obs)
         self.assertCountEqual(exp_keys, obs.keys())
-        self.assertCountEqual(obs['columns'], ['sampleId', 'rank_1', 'rank_2'])
+        self.assertCountEqual(obs['columns'], [{'data': 'sampleId'},
+                                               {'data': 'rank_1'},
+                                               {'data': 'rank_2'}])
         for item in obs['data']:
             self.assertCountEqual(item.keys(), ['sampleId', 'rank_1',
                                                 'rank_2'])

--- a/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
@@ -5,11 +5,13 @@ from numpy.testing import assert_allclose
 import json
 from unittest.mock import patch, PropertyMock
 from microsetta_public_api.repo._taxonomy_repo import TaxonomyRepo
+from microsetta_public_api.models._taxonomy import Taxonomy as TaxonomyModel
+from microsetta_public_api.utils import DataTable
 from microsetta_public_api.utils.testing import MockedJsonifyTestCase
 from microsetta_public_api.api.taxonomy import (
     resources, summarize_group, _summarize_group, single_sample,
+    group_taxa_present, single_sample_taxa_present,
 )
-from microsetta_public_api.models._taxonomy import Taxonomy as TaxonomyModel
 
 
 class TaxonomyImplementationTests(MockedJsonifyTestCase):
@@ -429,3 +431,119 @@ class TaxonomyImplementationTests(MockedJsonifyTestCase):
                         )
         assert_allclose([0, 0],
                         obs['feature_variances'])
+
+
+class TaxonomyTaxaPresentDataTableImplementationTests(MockedJsonifyTestCase):
+
+    jsonify_to_patch = [
+        'microsetta_public_api.api.taxonomy.jsonify',
+        'microsetta_public_api.utils._utils.jsonify',
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.post_body = {'sample_ids': ['sample-1',
+                                        'sample-2',
+                                        ]}
+        cls.table = biom.Table(np.array([[0, 1, 2],
+                                         [2, 4, 6],
+                                         [3, 0, 1]]),
+                               ['feature-1', 'feature-2', 'feature-3'],
+                               ['sample-1', 'sample-2', 'sample-3'])
+        cls.taxonomy_df = pd.DataFrame([['feature-1', 'a; b; c', 0.123],
+                                        ['feature-2', 'a; b; c; d; e', 0.345],
+                                        ['feature-3', 'a; f; g; h', 0.678]],
+                                       columns=['Feature ID', 'Taxon',
+                                                'Confidence'])
+        cls.taxonomy_df.set_index('Feature ID', inplace=True)
+
+        # variances
+        cls.table_vars = biom.Table(np.array([[0, 1, 2],
+                                              [2, 4, 6],
+                                              [3, 0, 1]]),
+                                    ['feature-1', 'feature-2', 'feature-3'],
+                                    ['sample-1', 'sample-2', 'sample-3'])
+        cls.taxonomy_model = TaxonomyModel(cls.table, cls.taxonomy_df,
+                                           cls.table_vars)
+
+    def test_single_sample_taxa_data_table(self):
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo.'
+                   'tables', new_callable=PropertyMock) as mock_tables, \
+                patch.object(TaxonomyModel, 'presence_data_table') as \
+                mock_model:
+            mock_tables.return_value = {
+                'some-table': {
+                    'table': self.table,
+                    'feature-data-taxonomy': self.taxonomy_df,
+                    'variances': self.table_vars,
+                    'model': self.taxonomy_model,
+                },
+            }
+            mock_model.return_value = DataTable.from_dataframe(
+                pd.DataFrame({
+                    'sampleId': ['sample-1', 'sample-1'],
+                    'rank_1': ['a', 'a'],
+                    'rank_2': ['b', 'f'],
+                })
+            )
+            response, code = single_sample_taxa_present(
+                'sample-1', "some-table")
+
+        self.assertEqual(code, 200)
+        exp_keys = ['data', 'columns']
+        obs = json.loads(response)
+        print(obs)
+        self.assertCountEqual(exp_keys, obs.keys())
+        self.assertCountEqual(obs['columns'], ['sampleId', 'rank_1', 'rank_2'])
+        for item in obs['data']:
+            self.assertCountEqual(item.keys(), ['sampleId', 'rank_1',
+                                                'rank_2'])
+
+    def test_group_taxa_data_table(self):
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo.'
+                   'tables', new_callable=PropertyMock) as mock_tables, \
+                patch.object(TaxonomyModel, 'presence_data_table') as \
+                mock_model:
+            mock_tables.return_value = {
+                'some-table': {
+                    'table': self.table,
+                    'feature-data-taxonomy': self.taxonomy_df,
+                    'variances': self.table_vars,
+                    'model': self.taxonomy_model,
+                },
+            }
+            mock_model.return_value = DataTable.from_dataframe(
+                pd.DataFrame({
+                    'sampleId': ['sample-1', 'sample-1', 'sample-2'],
+                    'rank_1': ['a', 'a', 'a'],
+                    'rank_2': ['b', 'f', 'b'],
+                })
+            )
+            response, code = group_taxa_present(
+                {'sample_ids': ['sample-1', 'sample-2']}, "some-table")
+
+        self.assertEqual(code, 200)
+        exp_keys = ['data', 'columns']
+        obs = json.loads(response)
+        print(obs)
+        self.assertCountEqual(exp_keys, obs.keys())
+        self.assertCountEqual(obs['columns'], ['sampleId', 'rank_1', 'rank_2'])
+        for item in obs['data']:
+            self.assertCountEqual(item.keys(), ['sampleId', 'rank_1',
+                                                'rank_2'])
+
+    def test_group_taxa_data_table_404(self):
+        with patch('microsetta_public_api.repo._taxonomy_repo.TaxonomyRepo.'
+                   'tables', new_callable=PropertyMock) as mock_tables:
+            mock_tables.return_value = {
+                'some-table': {
+                    'table': self.table,
+                    'feature-data-taxonomy': self.taxonomy_df,
+                    'variances': self.table_vars,
+                    'model': self.taxonomy_model,
+                },
+            }
+            response, code = group_taxa_present(
+                {'sample_ids': ['sample-1', 'dne-sample']}, "some-table")
+
+        self.assertEqual(code, 404)

--- a/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
@@ -492,7 +492,6 @@ class TaxonomyTaxaPresentDataTableImplementationTests(MockedJsonifyTestCase):
         self.assertEqual(code, 200)
         exp_keys = ['data', 'columns']
         obs = json.loads(response)
-        print(obs)
         self.assertCountEqual(exp_keys, obs.keys())
         self.assertCountEqual(obs['columns'], [{'data': 'sampleId'},
                                                {'data': 'rank_1'},
@@ -527,7 +526,6 @@ class TaxonomyTaxaPresentDataTableImplementationTests(MockedJsonifyTestCase):
         self.assertEqual(code, 200)
         exp_keys = ['data', 'columns']
         obs = json.loads(response)
-        print(obs)
         self.assertCountEqual(exp_keys, obs.keys())
         self.assertCountEqual(obs['columns'], [{'data': 'sampleId'},
                                                {'data': 'rank_1'},

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -353,7 +353,7 @@ class TaxonomyIntegrationTests(IntegrationTests):
         obs = json.loads(response.data)
 
         exp_columns = ['sampleId', 'Kingdom', 'Phylum', 'Class', 'Order',
-                       'Family', 'Genus', 'Species']
+                       'Family', 'Genus', 'Species', 'relativeAbundance']
         DataEntry = create_data_entry(exp_columns)
         exp = DataTable(
             data=[
@@ -366,6 +366,7 @@ class TaxonomyIntegrationTests(IntegrationTests):
                     'Family': 'd',
                     'Genus': 'e',
                     'Species': None,
+                    'relativeAbundance': 2. / 5,
                 }),
                 DataEntry(**{
                     'sampleId': 'sample-1',
@@ -376,6 +377,7 @@ class TaxonomyIntegrationTests(IntegrationTests):
                     'Family': 'h',
                     'Genus': None,
                     'Species': None,
+                    'relativeAbundance': 3. / 5,
                 }),
                 DataEntry(**{
                     'sampleId': 'sample-2',
@@ -386,6 +388,7 @@ class TaxonomyIntegrationTests(IntegrationTests):
                     'Family': None,
                     'Genus': None,
                     'Species': None,
+                    'relativeAbundance': 1. / 5,
                 }),
                 DataEntry(**{
                     'sampleId': 'sample-2',
@@ -396,6 +399,7 @@ class TaxonomyIntegrationTests(IntegrationTests):
                     'Family': 'd',
                     'Genus': 'e',
                     'Species': None,
+                    'relativeAbundance': 4. / 5,
                 }),
             ],
             columns=[{'data': col} for col in exp_columns],

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -175,7 +175,7 @@ class TaxonomyIntegrationTests(IntegrationTests):
                                         columns=['Feature ID', 'Taxon',
                                                  'Confidence'])
         self.taxonomy_greengenes_df = pd.DataFrame(
-            [['feature-1', 'k__a; p__b; o__c', 0.123],
+            [['feature-1', 'k__a;p__b; o__c', 0.123],
              ['feature-2', 'k__a; p__b; o__c; f__d; g__e', 0.34],
              ['feature-3', 'k__a; p__f; o__g; f__h', 0.678]],
             columns=['Feature ID', 'Taxon', 'Confidence'])

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -10,6 +10,7 @@ from microsetta_public_api import config
 from microsetta_public_api.resources import resources
 from microsetta_public_api.utils.testing import FlaskTests, \
     TempfileTestCase, ConfigTestCase
+from microsetta_public_api.utils import create_data_entry, DataTable
 
 
 class IntegrationTests(FlaskTests, TempfileTestCase, ConfigTestCase):
@@ -159,6 +160,8 @@ class TaxonomyIntegrationTests(IntegrationTests):
         self.table3_filename = self.create_tempfile(suffix='.qza').name
         self.var_table_filename = self.create_tempfile(suffix='.qza').name
         self.table_biom = self.create_tempfile(suffix='.biom').name
+        self.taxonomy_greengenes_df_filename = self.create_tempfile(
+            suffix='.qza').name
 
         self.table = biom.Table(np.array([[0, 1, 2],
                                           [2, 4, 6],
@@ -171,6 +174,13 @@ class TaxonomyIntegrationTests(IntegrationTests):
                                          ['feature-3', 'a; f; g; h', 0.678]],
                                         columns=['Feature ID', 'Taxon',
                                                  'Confidence'])
+        self.taxonomy_greengenes_df = pd.DataFrame(
+            [['feature-1', 'k__a; p__b; o__c', 0.123],
+             ['feature-2', 'k__a; p__b; o__c; f__d; g__e', 0.34],
+             ['feature-3', 'k__a; p__f; o__g; f__h', 0.678]],
+            columns=['Feature ID', 'Taxon', 'Confidence'])
+        self.taxonomy_greengenes_df.set_index('Feature ID', inplace=True)
+
         self.taxonomy_df.set_index('Feature ID', inplace=True)
 
         self.table2 = biom.Table(np.array([[0, 1, 2],
@@ -212,6 +222,12 @@ class TaxonomyIntegrationTests(IntegrationTests):
         imported_artifact.save(self.table3_filename)
         with biom_open(self.table_biom, 'w') as f:
             self.table.to_hdf5(f, 'test-table')
+
+        imported_artifact = Artifact.import_data(
+            "FeatureData[Taxonomy]", self.taxonomy_greengenes_df
+        )
+        imported_artifact.save(self.taxonomy_greengenes_df_filename)
+
         config.resources.update({'table_resources': {
             'table1': {
                 'table': self.table1_filename,
@@ -219,6 +235,10 @@ class TaxonomyIntegrationTests(IntegrationTests):
             'table2': {
                 'table': self.table1_filename,
                 'feature-data-taxonomy': self.taxonomy1_filename,
+            },
+            'table2-greengenes': {
+                'table': self.table1_filename,
+                'feature-data-taxonomy': self.taxonomy_greengenes_df_filename,
             },
             'table-fish': {
                 'table': self.table_biom,
@@ -247,7 +267,8 @@ class TaxonomyIntegrationTests(IntegrationTests):
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertIn('resources', obs)
-        self.assertCountEqual(['table2', 'table-fish', 'table-cached-model'],
+        self.assertCountEqual(['table2', 'table-fish', 'table-cached-model',
+                               'table2-greengenes'],
                               obs['resources'])
 
     def test_summarize_group(self):
@@ -319,6 +340,87 @@ class TaxonomyIntegrationTests(IntegrationTests):
         assert_allclose([0, 0],
                         obs['feature_variances']
                         )
+
+    def test_group_data_table(self):
+        response = self.client.post('/api/taxonomy/present/group/'
+                                    'table2-greengenes',
+                                    content_type='application/json',
+                                    data=json.dumps({'sample_ids': [
+                                        'sample-1', 'sample-2']}))
+
+        self.assertEqual(response.status_code, 200)
+
+        obs = json.loads(response.data)
+
+        exp_columns = ['sampleId', 'Kingdom', 'Phylum', 'Class', 'Order',
+                       'Family', 'Genus', 'Species']
+        DataEntry = create_data_entry(exp_columns)
+        exp = DataTable(
+            data=[
+                DataEntry(**{
+                    'sampleId': 'sample-1',
+                    'Kingdom': 'a',
+                    'Phylum': 'b',
+                    'Class': None,
+                    'Order': 'c',
+                    'Family': 'd',
+                    'Genus': 'e',
+                    'Species': None,
+                }),
+                DataEntry(**{
+                    'sampleId': 'sample-1',
+                    'Kingdom': 'a',
+                    'Phylum': 'f',
+                    'Class': None,
+                    'Order': 'g',
+                    'Family': 'h',
+                    'Genus': None,
+                    'Species': None,
+                }),
+                DataEntry(**{
+                    'sampleId': 'sample-2',
+                    'Kingdom': 'a',
+                    'Phylum': 'b',
+                    'Class': None,
+                    'Order': 'c',
+                    'Family': None,
+                    'Genus': None,
+                    'Species': None,
+                }),
+                DataEntry(**{
+                    'sampleId': 'sample-2',
+                    'Kingdom': 'a',
+                    'Phylum': 'b',
+                    'Class': None,
+                    'Order': 'c',
+                    'Family': 'd',
+                    'Genus': 'e',
+                    'Species': None,
+                }),
+            ],
+            columns=[{'data': col} for col in exp_columns],
+        ).to_dict()
+
+        self.assertListEqual(exp['columns'],
+                             obs['columns'])
+        # wouldn't want to do this on a huge dataframe..., but it checks if
+        #  there is a row of obs corresponding to each row of exp...
+        exp_df = pd.DataFrame(exp['data'])
+        obs_df = pd.DataFrame(obs['data'])
+        obs_df_copy = obs_df.copy()
+        for e_idx, row_exp in exp_df.iterrows():
+            for o_idx, row_obs in obs_df.iterrows():
+                if row_exp.eq(row_obs).all():
+                    obs_df_copy.drop(index=o_idx, inplace=True)
+                    break
+        self.assertTrue(obs_df_copy.empty)
+
+    def test_single_sample_data_table(self):
+        response = self.client.get(
+            '/api/taxonomy/present/single/table2/sample-1'
+        )
+
+        self.assertEqual(response.status_code, 200)
 
 
 class AlphaIntegrationTests(IntegrationTests):

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -260,7 +260,7 @@ class GreengenesFormatter(Formatter):
 
     @classmethod
     def dict_format(cls, taxonomy_string: str):
-        ranks = taxonomy_string.split('; ')
+        ranks = [rank_.strip() for rank_ in taxonomy_string.split(';')]
         formatted = OrderedDict()
 
         for rank in ranks:

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -223,11 +223,15 @@ class Taxonomy(ModelBase):
         # ... this is a bear. Basically, add sample_id to the taxonomy
         #  information, for each non zero entry in the table. Make a
         #  DataFrame on this
-        sample_data = pd.DataFrame([{**{'sampleId': sample_id},
+        sample_data = pd.DataFrame([{**{'sampleId': sample_id,
+                                        'relativeAbundance':
+                                            table.get_value_by_ids(
+                                            feature, sample_id)},
                                      **feature_data[feature]}
                                     for feature, sample_id in table.nonzero()],
                                    # this enforces the column order
-                                   columns=['sampleId'] + formatter.labels,
+                                   columns=['sampleId'] + formatter.labels +
+                                           ['relativeAbundance'],
                                    # need the .astype('object') in case a
                                    # column is completely empty (filled with
                                    # Nan, default dtype is numeric,

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -234,12 +234,11 @@ class Taxonomy(ModelBase):
                 }
                 entries.append(entry)
 
-        column_labels = ['sampleId'] + self._formatter.labels + [
-                'relativeAbundance'],
         sample_data = pd.DataFrame(
             entries,
             # this enforces the column order
-            columns=column_labels,
+            columns=['sampleId'] + self._formatter.labels + [
+                'relativeAbundance'],
             # need the .astype('object') in case a
             # column is completely empty (filled with
             # Nan, default dtype is numeric,

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -1,6 +1,6 @@
 from collections import namedtuple, OrderedDict
 from typing import Iterable, Dict, Optional, List
-from abc import abstractclassmethod
+from abc import abstractmethod
 
 import skbio
 import biom
@@ -91,7 +91,9 @@ class Taxonomy(ModelBase):
     """Represent the full taxonomy and facilitate table oriented retrieval"""
 
     def __init__(self, table: biom.Table, features: pd.DataFrame,
-                 variances: biom.Table = None):
+                 variances: biom.Table = None,
+                 formatter: Optional['Formatter'] = None
+                 ):
         """Establish the taxonomy data
 
         Parameters
@@ -132,6 +134,15 @@ class Taxonomy(ModelBase):
         self._features = self._features.loc[self._feature_order]
         self._variances = self._variances.sort_order(self._feature_order,
                                                      axis='observation')
+
+        if formatter is None:
+            formatter: Formatter = GreengenesFormatter()
+        self._formatter = formatter
+
+        feature_taxons = self._features
+        self._formatted_taxa_names = {i: self._formatter.dict_format(lineage)
+                                      for i, lineage in
+                                      feature_taxons['Taxon'].items()}
 
     def _get_sample_ids(self) -> np.ndarray:
         return self._table.ids()
@@ -209,16 +220,9 @@ class Taxonomy(ModelBase):
                              feature_ranks=None,
                              )
 
-    def presence_data_table(self, ids: Iterable[str],
-                            formatter: Optional['Formatter'] = None) -> \
-            DataTable:
-        if formatter is None:
-            formatter: Formatter = GreengenesFormatter()
+    def presence_data_table(self, ids: Iterable[str]) -> DataTable:
         table = self._table.filter(set(ids), inplace=False).remove_empty()
         features = table.ids(axis='observation')
-        feature_taxons = self._features.loc[features]
-        feature_data = {i: formatter.dict_format(lineage)
-                        for i, lineage in feature_taxons['Taxon'].items()}
 
         entries = list()
         for vec, sample_id, _ in table.iter(dense=False):
@@ -226,13 +230,15 @@ class Taxonomy(ModelBase):
                 entries.append({
                     **{'sampleId': sample_id,
                        'relativeAbundance': val},
-                    **feature_data[features[feature_idx]],
+                    **self._formatted_taxa_names[features[feature_idx]],
                 })
 
         sample_data = pd.DataFrame(entries,
                                    # this enforces the column order
-                                   columns=['sampleId'] + formatter.labels +
-                                           ['relativeAbundance'],
+                                   columns=
+                                   ['sampleId'] +
+                                   self._formatter.labels +
+                                   ['relativeAbundance'],
                                    # need the .astype('object') in case a
                                    # column is completely empty (filled with
                                    # Nan, default dtype is numeric,
@@ -248,8 +254,9 @@ class Formatter:
 
     labels: List
 
-    @abstractclassmethod
-    def dict_format(self, taxonomy_string):
+    @classmethod
+    @abstractmethod
+    def dict_format(cls, taxonomy_string):
         raise NotImplementedError()
 
 

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -220,15 +220,16 @@ class Taxonomy(ModelBase):
         feature_data = {i: formatter.dict_format(lineage)
                         for i, lineage in feature_taxons['Taxon'].items()}
 
-        # ... this is a bear. Basically, add sample_id to the taxonomy
-        #  information, for each non zero entry in the table. Make a
-        #  DataFrame on this
-        sample_data = pd.DataFrame([{**{'sampleId': sample_id,
-                                        'relativeAbundance':
-                                            table.get_value_by_ids(
-                                            feature, sample_id)},
-                                     **feature_data[feature]}
-                                    for feature, sample_id in table.nonzero()],
+        entries = list()
+        for vec, sample_id, _ in table.iter(dense=False):
+            for feature_idx, val in zip(vec.indices, vec.data):
+                entries.append({
+                    **{'sampleId': sample_id,
+                       'relativeAbundance': val},
+                    **feature_data[features[feature_idx]],
+                })
+
+        sample_data = pd.DataFrame(entries,
                                    # this enforces the column order
                                    columns=['sampleId'] + formatter.labels +
                                            ['relativeAbundance'],

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -233,19 +233,19 @@ class Taxonomy(ModelBase):
                     **self._formatted_taxa_names[features[feature_idx]],
                 })
 
-        sample_data = pd.DataFrame(entries,
-                                   # this enforces the column order
-                                   columns=
-                                   ['sampleId'] +
-                                   self._formatter.labels +
-                                   ['relativeAbundance'],
-                                   # need the .astype('object') in case a
-                                   # column is completely empty (filled with
-                                   # Nan, default dtype is numeric,
-                                   # which cannot be replaced with None.
-                                   # Need None because it is valid for JSON,
-                                   # but NaN is not.
-                                   ).astype('object')
+        column_labels = ['sampleId'] + self._formatter.labels + [
+                'relativeAbundance'],
+        sample_data = pd.DataFrame(
+            entries,
+            # this enforces the column order
+            columns=column_labels,
+            # need the .astype('object') in case a
+            # column is completely empty (filled with
+            # Nan, default dtype is numeric,
+            # which cannot be replaced with None.
+            # Need None because it is valid for JSON,
+            # but NaN is not.
+           ).astype('object')
         sample_data[pd.isna(sample_data)] = None
         return DataTable.from_dataframe(sample_data)
 

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -227,11 +227,12 @@ class Taxonomy(ModelBase):
         entries = list()
         for vec, sample_id, _ in table.iter(dense=False):
             for feature_idx, val in zip(vec.indices, vec.data):
-                entries.append({
-                    **{'sampleId': sample_id,
-                       'relativeAbundance': val},
+                entry = {
+                    'sampleId': sample_id,
+                    'relativeAbundance': val,
                     **self._formatted_taxa_names[features[feature_idx]],
-                })
+                }
+                entries.append(entry)
 
         column_labels = ['sampleId'] + self._formatter.labels + [
                 'relativeAbundance'],

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -223,11 +223,11 @@ class Taxonomy(ModelBase):
         # ... this is a bear. Basically, add sample_id to the taxonomy
         #  information, for each non zero entry in the table. Make a
         #  DataFrame on this
-        sample_data = pd.DataFrame([{**{'SampleID': sample_id},
+        sample_data = pd.DataFrame([{**{'sampleId': sample_id},
                                      **feature_data[feature]}
                                     for feature, sample_id in table.nonzero()],
                                    # this enforces the column order
-                                   columns=['SampleID'] + formatter.labels,
+                                   columns=['sampleId'] + formatter.labels,
                                    # need the .astype('object') in case a
                                    # column is completely empty (filled with
                                    # Nan, default dtype is numeric,

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -1,6 +1,6 @@
 from collections import namedtuple, OrderedDict
 from typing import Iterable, Dict, Optional, List
-from abc import abstractmethod
+from abc import abstractclassmethod
 
 import skbio
 import biom
@@ -248,7 +248,7 @@ class Formatter:
 
     labels: List
 
-    @abstractmethod
+    @abstractclassmethod
     def dict_format(self, taxonomy_string):
         raise NotImplementedError()
 

--- a/microsetta_public_api/models/tests/test_taxonomy.py
+++ b/microsetta_public_api/models/tests/test_taxonomy.py
@@ -39,7 +39,7 @@ class TaxonomyTests(unittest.TestCase):
         self.taxonomy2_df.set_index('Feature ID', inplace=True)
         self.taxonomy_greengenes_df = pd.DataFrame(
             [['feature-1', 'k__a; p__b; o__c', 0.123],
-             ['feature-2', 'k__a; p__b; o__c; f__d; g__e', 0.34],
+             ['feature-2', 'k__a; p__b; o__c;f__d;g__e', 0.34],
              ['feature-3', 'k__a; p__f; o__g; f__h', 0.678]],
             columns=['Feature ID', 'Taxon', 'Confidence'])
         self.taxonomy_greengenes_df.set_index('Feature ID', inplace=True)

--- a/microsetta_public_api/models/tests/test_taxonomy.py
+++ b/microsetta_public_api/models/tests/test_taxonomy.py
@@ -157,7 +157,7 @@ class TaxonomyTests(unittest.TestCase):
         obs = taxonomy.presence_data_table(['sample-1', 'sample-2'])
 
         exp_columns = ['sampleId', 'Kingdom', 'Phylum', 'Class', 'Order',
-                       'Family', 'Genus', 'Species']
+                       'Family', 'Genus', 'Species', 'relativeAbundance']
         DataEntry = create_data_entry(exp_columns)
         exp = DataTable(
             data=[
@@ -170,6 +170,7 @@ class TaxonomyTests(unittest.TestCase):
                     'Family': 'd',
                     'Genus': 'e',
                     'Species': None,
+                    'relativeAbundance': 2. / 5,
                 }),
                 DataEntry(**{
                     'sampleId': 'sample-1',
@@ -180,6 +181,7 @@ class TaxonomyTests(unittest.TestCase):
                     'Family': 'h',
                     'Genus': None,
                     'Species': None,
+                    'relativeAbundance': 3. / 5,
                 }),
                 DataEntry(**{
                     'sampleId': 'sample-2',
@@ -190,6 +192,7 @@ class TaxonomyTests(unittest.TestCase):
                     'Family': None,
                     'Genus': None,
                     'Species': None,
+                    'relativeAbundance': 1. / 5,
                 }),
                 DataEntry(**{
                     'sampleId': 'sample-2',
@@ -200,6 +203,7 @@ class TaxonomyTests(unittest.TestCase):
                     'Family': 'd',
                     'Genus': 'e',
                     'Species': None,
+                    'relativeAbundance': 4. / 5,
                 }),
             ],
             columns=exp_columns,

--- a/microsetta_public_api/models/tests/test_taxonomy.py
+++ b/microsetta_public_api/models/tests/test_taxonomy.py
@@ -156,13 +156,13 @@ class TaxonomyTests(unittest.TestCase):
                             self.table_vars)
         obs = taxonomy.presence_data_table(['sample-1', 'sample-2'])
 
-        exp_columns = ['SampleID', 'Kingdom', 'Phylum', 'Class', 'Order',
+        exp_columns = ['sampleId', 'Kingdom', 'Phylum', 'Class', 'Order',
                        'Family', 'Genus', 'Species']
         DataEntry = create_data_entry(exp_columns)
         exp = DataTable(
             data=[
                 DataEntry(**{
-                    'SampleID': 'sample-1',
+                    'sampleId': 'sample-1',
                     'Kingdom': 'a',
                     'Phylum': 'b',
                     'Class': None,
@@ -172,7 +172,7 @@ class TaxonomyTests(unittest.TestCase):
                     'Species': None,
                 }),
                 DataEntry(**{
-                    'SampleID': 'sample-1',
+                    'sampleId': 'sample-1',
                     'Kingdom': 'a',
                     'Phylum': 'f',
                     'Class': None,
@@ -182,7 +182,7 @@ class TaxonomyTests(unittest.TestCase):
                     'Species': None,
                 }),
                 DataEntry(**{
-                    'SampleID': 'sample-2',
+                    'sampleId': 'sample-2',
                     'Kingdom': 'a',
                     'Phylum': 'b',
                     'Class': None,
@@ -192,7 +192,7 @@ class TaxonomyTests(unittest.TestCase):
                     'Species': None,
                 }),
                 DataEntry(**{
-                    'SampleID': 'sample-2',
+                    'sampleId': 'sample-2',
                     'Kingdom': 'a',
                     'Phylum': 'b',
                     'Class': None,
@@ -204,7 +204,8 @@ class TaxonomyTests(unittest.TestCase):
             ],
             columns=exp_columns,
         )
-        self.assertListEqual(exp.columns, obs.columns)
+        self.assertListEqual([{'data': col} for col in exp.columns],
+                             obs.columns)
         # wouldn't want to do this on a huge dataframe..., but it checks if
         #  there is a row of obs corresponding to each row of exp...
         exp_df = pd.DataFrame(exp.data)

--- a/microsetta_public_api/utils/__init__.py
+++ b/microsetta_public_api/utils/__init__.py
@@ -1,3 +1,12 @@
-from microsetta_public_api.utils._utils import jsonify
+from microsetta_public_api.utils._utils import (
+    jsonify,
+    DataTable,
+    create_data_entry,
+)
 
-__all__ = ['testing', 'jsonify']
+__all__ = [
+    'testing',
+    'jsonify',
+    'DataTable',
+    'create_data_entry',
+]

--- a/microsetta_public_api/utils/_utils.py
+++ b/microsetta_public_api/utils/_utils.py
@@ -69,7 +69,7 @@ class DataTable(_data_table):
         """
         DataEntry = create_data_entry(df.columns)
         data = df.apply(lambda x: DataEntry(*x), axis=1).values.tolist()
-        columns = list(df.columns)
+        columns = [{"data": col} for col in df.columns]
         return cls(data, columns)
 
 

--- a/microsetta_public_api/utils/_utils.py
+++ b/microsetta_public_api/utils/_utils.py
@@ -44,8 +44,7 @@ class DataTable(_data_table):
     """
     def to_dict(self):
         dict_ = self._asdict()
-        dict_['data'] = [entry.to_dict() for entry in
-                         enumerate(self.data)]
+        dict_['data'] = [entry.to_dict() for entry in self.data]
         return dict_
 
     @classmethod

--- a/microsetta_public_api/utils/_utils.py
+++ b/microsetta_public_api/utils/_utils.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 from flask import jsonify as flask_jsonify
 
 
@@ -19,3 +21,64 @@ def check_missing_ids(missing_ids, alpha_metric, type_):
                        error=404, text=f"Sample ID(s) not found for "
                                        f"{type_}: {alpha_metric}"), \
                404
+
+
+_data_table = namedtuple('DataTable', ['data', 'columns'])
+
+
+class DataTable(_data_table):
+    """A convenience class for constructing jQuery a DataTable in python
+    that is JSON serializable.
+
+    A DataTable should have data entries and a list of columns that are in
+    the entries.
+
+    Attributes
+    ----------
+
+    data : list of DataEntry
+        The entries that comprise the DataTable
+    columns : list of str
+        The names of the columns in the DataTable
+
+    """
+    def to_dict(self):
+        data = self.data.copy()
+        for i, entry in enumerate(data):
+            # this hinges on the entries of data being DataEntry, since we
+            # know they have a .to_dict() method
+            data[i] = entry.to_dict()
+        dict_ = self._asdict()
+        dict_['data'] = data
+        return dict_
+
+    @classmethod
+    def from_dataframe(cls, df):
+        """
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The DataFrame to create a DataTable from.
+
+        Returns
+        -------
+        DataTable
+            A DataTable corresponding to DataFrame
+
+        """
+        DataEntry = create_data_entry(df.columns)
+        data = df.apply(lambda x: DataEntry(*x), axis=1).values.tolist()
+        columns = list(df.columns)
+        return cls(data, columns)
+
+
+def create_data_entry(columns):
+    _data_entry_class = namedtuple('DataEntry', columns)
+
+    class DataEntry(_data_entry_class):
+
+        def to_dict(self):
+            return self._asdict()
+
+    return DataEntry

--- a/microsetta_public_api/utils/_utils.py
+++ b/microsetta_public_api/utils/_utils.py
@@ -43,13 +43,9 @@ class DataTable(_data_table):
 
     """
     def to_dict(self):
-        data = self.data.copy()
-        for i, entry in enumerate(data):
-            # this hinges on the entries of data being DataEntry, since we
-            # know they have a .to_dict() method
-            data[i] = entry.to_dict()
         dict_ = self._asdict()
-        dict_['data'] = data
+        dict_['data'] = [entry.to_dict() for entry in
+                         enumerate(self.data)]
         return dict_
 
     @classmethod

--- a/microsetta_public_api/utils/tests/test_utils.py
+++ b/microsetta_public_api/utils/tests/test_utils.py
@@ -49,6 +49,8 @@ class TestDataTable(TestCase):
 
         dt = DataTable.from_dataframe(df)
 
+        dict_['columns'] = [{'data': 'foo'}, {'data': 'bar'}]
+
         obs_dict = dt.to_dict()
         obs = json.dumps(obs_dict)
         exp = json.dumps(dict_)

--- a/microsetta_public_api/utils/tests/test_utils.py
+++ b/microsetta_public_api/utils/tests/test_utils.py
@@ -1,6 +1,9 @@
 from unittest.case import TestCase
 
 from microsetta_public_api.utils.testing import mocked_jsonify
+from microsetta_public_api.utils import DataTable, create_data_entry
+import json
+import pandas as pd
 
 
 class MockedJsonifyTests(TestCase):
@@ -11,3 +14,42 @@ class MockedJsonifyTests(TestCase):
         mocked_jsonify('a', 'b', 'c')
         with self.assertRaises(TypeError):
             mocked_jsonify({'a': 'b', 'c': 'd'}, e='f')
+
+
+class TestDataTable(TestCase):
+
+    def test_data_entry(self):
+        DataEntry = create_data_entry(['foo', 'bar'])
+        obs = DataEntry(foo='baz', bar='qux')
+        exp = {'foo': 'baz', 'bar': 'qux'}
+        self.assertDictEqual(exp, obs.to_dict())
+
+    def test_data_table(self):
+        DataEntry = create_data_entry(['foo', 'bar'])
+        entry1 = DataEntry(foo='baz', bar='qux')
+        entry2 = DataEntry(foo='quuz', bar='corge')
+
+        dt = DataTable(data=[entry1, entry2], columns=['foo', 'bar'])
+        obs_dict = dt.to_dict()
+        exp_dict = {'data': [{'foo': 'baz', 'bar': 'qux'}, {'foo': 'quuz',
+                                                            'bar': 'corge'}],
+                    'columns': ['foo', 'bar'],
+                    }
+
+        obs = json.dumps(obs_dict)
+        exp = json.dumps(exp_dict)
+        self.assertEqual(obs, exp)
+
+    def test_data_table_from_dataframe(self):
+        dict_ = {'data': [{'foo': 'baz', 'bar': 'qux'}, {'foo': 'quuz',
+                                                         'bar': 'corge'}],
+                 'columns': ['foo', 'bar'],
+                 }
+        df = pd.DataFrame(dict_['data'], columns=dict_['columns'])
+
+        dt = DataTable.from_dataframe(df)
+
+        obs_dict = dt.to_dict()
+        obs = json.dumps(obs_dict)
+        exp = json.dumps(dict_)
+        self.assertEqual(obs, exp)


### PR DESCRIPTION
Fixes #27 . Implements #33 .

This adds the guts for the new taxonomy endpoint. Has potential for forward compatibility with differing taxonomy formats.

Also introduces a `DataTable` class and `create_data_entry` utility that should hopefully aid future development of endpoints that rely on formatting a js DataTable.