### PR TITLE
Add endpoints from initial interface demo

### DIFF
--- a/microsetta_public_api/api/diversity/beta.py
+++ b/microsetta_public_api/api/diversity/beta.py
@@ -1,0 +1,2 @@
+def pcoa_contains(named_sample_set, sample_id):
+    raise NotImplementedError()

--- a/microsetta_public_api/api/emperor.py
+++ b/microsetta_public_api/api/emperor.py
@@ -1,0 +1,2 @@
+def plot_pcoa(beta_metric, named_sample_set, sample_id):
+    raise NotImplementedError()

--- a/microsetta_public_api/api/metadata.py
+++ b/microsetta_public_api/api/metadata.py
@@ -37,6 +37,10 @@ def filter_sample_ids(taxonomy=None, alpha_metric=None, **kwargs):
     return jsonify(sample_ids=matching_ids), 200
 
 
+def filter_sample_ids_query_builder(body, taxonomy=None, alpha_metric=None):
+    raise NotImplementedError()
+
+
 def _filter_matching_ids(matching_ids, repo, category, value, resource_type,
                          error_response=None, error_code=None):
     if value is not None:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -64,7 +64,6 @@ paths:
           description: Filter IDs to those present in the data for `alpha_metric`
           schema:
             $ref: '#/components/schemas/alphaMetric'
-
       responses:
         '200':
           description: Successfully returned sample ids
@@ -74,7 +73,6 @@ paths:
                 $ref: "#/components/schemas/sampleIdList"
         '404':
           $ref: '#/components/responses/404NotFound'
-
     post:
       operationId: microsetta_public_api.api.metadata.filter_sample_ids_query_builder
       tags:
@@ -98,7 +96,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/metadataQuery'
-
       responses:
         '200':
           description: Successfully returned sample ids
@@ -186,7 +183,6 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
-
   '/diversity/metrics/alpha/available':
     get:
       operationId: microsetta_public_api.api.diversity.alpha.available_metrics_alpha
@@ -249,7 +245,6 @@ paths:
         - Diversity
       summary: Query alpha diversity for a group of samples
       description: Query alpha diversity for a group of samples
-
       parameters:
         - $ref: '#/components/parameters/alphaMetric'
         - in: query
@@ -276,13 +271,11 @@ paths:
             Percentiles that should be returned. If not specified, then
             `10,20,30,40,50,60,70,80,90` will be used.
             Ignored if `summary_statistics=false`.
-
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/sampleIdList"
-
       responses:
         '200':
           description: Successfuly return alpha diversity information
@@ -360,15 +353,43 @@ paths:
                                 - 8.25
                                 - 9.01
                                 - 9.04
-
         '404':
           $ref: '#/components/responses/404NotFound'
         '400':
           description: >
             Either `summary_statistics`, `return_raw`, or both are required to be true.
 
-  '/plotting/diversity/beta/pcoa/{beta_metric}':
-    # TODO this should probably be more like '/plotting/diversity/beta/pcoa/{named_sample_set}
+  '/plotting/diversity/beta/pcoa/{named_sample_set}/contains/{sample_id}':
+    get:
+      operationId: microsettta_public_api.api.diversity.beta.pcoa_contains
+      tags:
+        - Beta Diversity
+      summary: Get whether the given `sample_id` is contained in the `named_sample_set`
+      description: Get whether the given `sample_id` is contained in the `named_sample_set`
+      parameters:
+        - in: path
+          name: named_sample_set
+          description: The named sample set that should be plotted
+          schema:
+            type: string
+            example: 'habitat-type'
+          required: true
+        - in: path
+          name: sample_id
+          schema:
+            $ref: '#/components/schemas/sampleId'
+          required: true
+      responses:
+        '200':
+          description: a `boolean`, which indicates if `sample_id` is contained in `named_sample_set`
+          content:
+            application/json:
+              schema:
+                type: boolean
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
+  '/plotting/diversity/beta/pcoa/{beta_metric}/{named_sample_set}':
     get:
       operationId: microsetta_public_api.api.plotting.plot_beta
       tags:
@@ -381,7 +402,14 @@ paths:
           name: beta_metric
           description: Plot the data for samples using this metric
           schema:
-            $ref: '#/components/schemas/alphaMetric' # TODO change to betaMetric
+            $ref: '#/components/schemas/betaMetric'
+          required: true
+        - in: path
+          name: named_sample_set
+          description: The named sample set that should be plotted
+          schema:
+            type: string
+            example: 'habitat-type'
           required: true
         - in: query
           name: sample_id
@@ -433,13 +461,11 @@ paths:
       description: Get taxonomy information for a group of samples
       parameters:
         - $ref: '#/components/parameters/taxonomyResource'
-
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/sampleIdList"
-
       responses:
         '200':
           description: Successfuly return taxonomy information
@@ -447,7 +473,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/taxonomyFeatures'
-
         '404':
           $ref: '#/components/responses/404NotFound'
 
@@ -461,7 +486,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/sampleId'
         - $ref: '#/components/parameters/taxonomyResource'
-
       responses:
         '200':
           description: Successfuly return taxonomy information
@@ -469,7 +493,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/taxonomyFeatures'
-
         '404':
           $ref: '#/components/responses/404NotFound'
 
@@ -482,13 +505,11 @@ paths:
       description: Get a DataTable of taxa, broken down by rank, for a list of samples
       parameters:
         - $ref: '#/components/parameters/taxonomyResource'
-
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/sampleIdList"
-
       responses:
         '200':
           description: Successfully return taxonomy table
@@ -496,7 +517,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/sampleDataTable'
-
         '404':
           $ref: '#/components/responses/404NotFound'
 
@@ -510,7 +530,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/sampleId'
         - $ref: '#/components/parameters/taxonomyResource'
-
       responses:
         '200':
           description: Successfully return taxonomy table
@@ -518,8 +537,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/sampleDataTable'
-
-        '404':
+         '404':
           $ref: '#/components/responses/404NotFound'
 
 components:
@@ -558,6 +576,9 @@ components:
     alphaMetric:
       type: string
       example: "faith_pd"
+    betaMetric:
+      type: string
+      example: "unifrac"
     metadataQuery:
       # TODO try to make this a little more informative (challenging due to recursive definition)
       type: object

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -80,18 +80,6 @@ paths:
         - Metadata
       summary: Query samples associated with query
       description: Query samples associated with query
-      parameters:
-        - in: query
-          name: taxonomy
-          description: Filter IDs to those present in the table associated with `taxonomy`
-          schema:
-            type: string
-            example: 'genus-level-taxonomy'
-        - in: query
-          name: alpha_metric
-          description: Filter IDs to those present in the data for `alpha_metric`
-          schema:
-            $ref: '#/components/schemas/alphaMetric'
       requestBody:
         content:
           application/json:
@@ -109,18 +97,9 @@ paths:
 
   '/plotting/diversity/alpha/{alpha_metric}/percentiles-plot':
     parameters:
-      - in: path
-        name: alpha_metric
-        description: Plot the data for samples using this metric
-        schema:
-          $ref: '#/components/schemas/alphaMetric'
-        required: true
-      - in: query
-        $ref: '#/components/parameters/percentiles'
-      - in: query
-        name: sample_id
-        schema:
-          $ref: '#/components/schemas/sampleId'
+      - $ref: '#/components/parameters/alphaMetric'
+      - $ref: '#/components/parameters/percentiles'
+      - $ref: '#/components/parameters/sampleIdQuery'
     get:
       operationId: microsetta_public_api.api.plotting.plot_alpha_filtered
       tags:
@@ -206,7 +185,7 @@ paths:
       summary: Get single sample alpha diversity
       description: Get single sample alpha diversity
       parameters:
-        - $ref: '#/components/parameters/sampleId'
+        - $ref: '#/components/parameters/sampleIdPath'
         - $ref: '#/components/parameters/alphaMetric'
       responses:
         '200':
@@ -348,7 +327,7 @@ paths:
           description: >
             Either `summary_statistics`, `return_raw`, or both are required to be true.
 
-  '/diversity/beta/pcoa/contains/{beta_metric}/{named_sample_set}/{sample_id}':
+  '/diversity/beta/pcoa/contains/{beta_metric}/{named_sample_set}':
     get:
       operationId: microsetta_public_api.api.diversity.beta.pcoa_contains
       tags:
@@ -356,24 +335,9 @@ paths:
       summary: Get whether the given `sample_id` is contained in the `named_sample_set`
       description: Get whether the given `sample_id` is contained in the `named_sample_set`
       parameters:
-        - in: path
-          name: beta_metric
-          description: Plot the data for samples using this metric
-          schema:
-            $ref: '#/components/schemas/betaMetric'
-          required: true
-        - in: path
-          name: named_sample_set
-          description: The named sample set that should be plotted
-          schema:
-            type: string
-            example: 'habitat-type'
-          required: true
-        - in: path
-          name: sample_id
-          schema:
-            $ref: '#/components/schemas/sampleId'
-          required: true
+        - $ref: '#/components/parameters/betaMetric'
+        - $ref: '#/components/parameters/namedSampleSet'
+        - $ref: '#/components/parameters/sampleIdQuery'
       responses:
         '200':
           description: a `boolean`, which indicates if `sample_id` is contained in `named_sample_set`
@@ -393,22 +357,9 @@ paths:
       summary: Get a Vega schema for PCOA plot
       description: Get a Vega schema for PCOA plot
       parameters:
-        - in: path
-          name: beta_metric
-          description: Plot the data for samples using this metric
-          schema:
-            $ref: '#/components/schemas/betaMetric'
-          required: true
-        - in: path
-          name: named_sample_set
-          description: The named sample set that should be plotted
-          schema:
-            $ref: '#/components/schemas/namedSampleSet'
-          required: true
-        - in: query
-          name: sample_id
-          schema:
-            $ref: '#/components/schemas/sampleId'
+        - $ref: '#/components/parameters/betaMetric'
+        - $ref: '#/components/parameters/namedSampleSet'
+        - $ref: '#/components/parameters/sampleIdQuery'
       responses:
         '200':
           description: Successfully returned Vega JSON
@@ -478,7 +429,7 @@ paths:
       summary: Get taxonomy information for a sample
       description: Get taxonomy information for a sample
       parameters:
-        - $ref: '#/components/parameters/sampleId'
+        - $ref: '#/components/parameters/sampleIdPath'
         - $ref: '#/components/parameters/taxonomyResource'
       responses:
         '200':
@@ -522,7 +473,7 @@ paths:
       summary: Get a DataTable of taxa, broken down by rank, for a given sample
       description: Get a DataTable of taxa, broken down by rank, for a given sample
       parameters:
-        - $ref: '#/components/parameters/sampleId'
+        - $ref: '#/components/parameters/sampleIdPath'
         - $ref: '#/components/parameters/taxonomyResource'
       responses:
         '200':
@@ -544,18 +495,8 @@ paths:
       summary: Get an Emperor compatible PCoA schema
       description: Get an Emperor compatible PCoA schema
       parameters:
-        - in: path
-          name: beta_metric
-          description: Plot the data for samples using this metric
-          schema:
-            $ref: '#/components/schemas/betaMetric'
-          required: true
-        - in: path
-          name: named_sample_set
-          description: The named sample set that should be plotted
-          schema:
-            $ref: '#/components/schemas/namedSampleSet'
-          required: true
+        - $ref: '#/components/parameters/betaMetric'
+        - $ref: '#/components/parameters/namedSampleSet'
       responses:
         '200':
           description: Successfully return Emperor Schema
@@ -575,9 +516,30 @@ components:
       schema:
         $ref: '#/components/schemas/alphaMetric'
       required: true
-    sampleId:
+    betaMetric:
+      name: beta_metric
+      in: path
+      description: Plot the data for samples using this metric
+      schema:
+        $ref: '#/components/schemas/betaMetric'
+      required: true
+    namedSampleSet:
+      name: named_sample_set
+      in: path
+      description: The named sample set that should be plotted
+      schema:
+        $ref: '#/components/schemas/namedSampleSet'
+      required: true
+    sampleIdPath:
       name: sample_id
       in: path
+      description: Unique id specifying a sample associated with a source
+      schema:
+        $ref: '#/components/schemas/sampleId'
+      required: true
+    sampleIdQuery:
+      name: sample_id
+      in: query
       description: Unique id specifying a sample associated with a source
       schema:
         $ref: '#/components/schemas/sampleId'

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -183,7 +183,7 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
-  '/diversity/metrics/alpha/available':
+  '/diversity/alpha/metrics/available':
     get:
       operationId: microsetta_public_api.api.diversity.alpha.available_metrics_alpha
       tags:
@@ -359,9 +359,9 @@ paths:
           description: >
             Either `summary_statistics`, `return_raw`, or both are required to be true.
 
-  '/plotting/diversity/beta/pcoa/{named_sample_set}/contains/{sample_id}':
+  '/diversity/beta/pcoa/{named_sample_set}/contains/{sample_id}':
     get:
-      operationId: microsettta_public_api.api.diversity.beta.pcoa_contains
+      operationId: microsetta_public_api.api.diversity.beta.pcoa_contains
       tags:
         - Beta Diversity
       summary: Get whether the given `sample_id` is contained in the `named_sample_set`

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -327,7 +327,7 @@ paths:
           description: >
             Either `summary_statistics`, `return_raw`, or both are required to be true.
 
-  '/diversity/beta/pcoa/contains/{beta_metric}/{named_sample_set}':
+  /diversity/beta/{beta_metric}/pcoa/{named_sample_set}/contains:
     get:
       operationId: microsetta_public_api.api.diversity.beta.pcoa_contains
       tags:
@@ -348,7 +348,7 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
-  '/plotting/diversity/beta/pcoa/{beta_metric}/{named_sample_set}':
+  '/plotting/diversity/beta/{beta_metric}/pcoa/{named_sample_set}/vega':
     get:
       operationId: microsetta_public_api.api.plotting.plot_beta
       tags:
@@ -485,7 +485,7 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
-  '/emperor/pcoa/{beta_metric}/{named_sample_set}':
+  '/plotting/diversity/beta/{beta_metric}/pcoa/{named_sample_set}/emperor':
     get:
       operationId: microsetta_public_api.api.emperor.plot_pcoa
       tags:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -359,7 +359,7 @@ paths:
           description: >
             Either `summary_statistics`, `return_raw`, or both are required to be true.
 
-  '/diversity/beta/pcoa/{named_sample_set}/contains/{sample_id}':
+  '/diversity/beta/pcoa/contains/{beta_metric}/{named_sample_set}/{sample_id}':
     get:
       operationId: microsetta_public_api.api.diversity.beta.pcoa_contains
       tags:
@@ -367,6 +367,12 @@ paths:
       summary: Get whether the given `sample_id` is contained in the `named_sample_set`
       description: Get whether the given `sample_id` is contained in the `named_sample_set`
       parameters:
+        - in: path
+          name: beta_metric
+          description: Plot the data for samples using this metric
+          schema:
+            $ref: '#/components/schemas/betaMetric'
+          required: true
         - in: path
           name: named_sample_set
           description: The named sample set that should be plotted

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -111,7 +111,7 @@ paths:
       operationId: microsetta_public_api.api.plotting.plot_alpha_filtered
       tags:
         - Plotting
-        - Diversity
+        - Alpha Diversity
       summary: Get a Vega schema for alpha diversity cdf matching criteria
       description: Get a Vega schema for alpha diversity cdf matching criteria
       parameters:
@@ -151,7 +151,7 @@ paths:
       operationId: microsetta_public_api.api.plotting.plot_alpha_filtered_json_query
       tags:
         - Plotting
-        - Diversity
+        - Alpha Diversity
       summary: Get a Vega schema for alpha diversity cdf matching criteria
       description: Get a Vega schema for alpha diversity cdf matching criteria
       parameters:
@@ -187,7 +187,7 @@ paths:
     get:
       operationId: microsetta_public_api.api.diversity.alpha.available_metrics_alpha
       tags:
-        - Diversity
+        - Alpha Diversity
       summary: Get available alpha diversity metrics
       description: Get available alpha diversity metrics
       responses:
@@ -213,7 +213,7 @@ paths:
     get:
       operationId: microsetta_public_api.api.diversity.alpha.get_alpha
       tags:
-        - Diversity
+        - Alpha Diversity
       summary: Get single sample alpha diversity
       description: Get single sample alpha diversity
       parameters:
@@ -242,7 +242,7 @@ paths:
     post:
       operationId: microsetta_public_api.api.diversity.alpha.alpha_group
       tags:
-        - Diversity
+        - Alpha Diversity
       summary: Query alpha diversity for a group of samples
       description: Query alpha diversity for a group of samples
       parameters:
@@ -537,7 +537,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/sampleDataTable'
-         '404':
+        '404':
           $ref: '#/components/responses/404NotFound'
 
 components:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -414,8 +414,7 @@ paths:
           name: named_sample_set
           description: The named sample set that should be plotted
           schema:
-            type: string
-            example: 'habitat-type'
+            $ref: '#/components/schemas/namedSampleSet'
           required: true
         - in: query
           name: sample_id
@@ -546,6 +545,38 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+  '/emperor/pcoa/{beta_metric}/{named_sample_set}':
+    get:
+      operationId: microsetta_public_api.api.emperor.plot_pcoa
+      tags:
+        - Plotting
+        - Beta Diversity
+        - Emperor
+      summary: Get an Emperor compatible PCoA schema
+      description: Get an Emperor compatible PCoA schema
+      parameters:
+        - in: path
+          name: beta_metric
+          description: Plot the data for samples using this metric
+          schema:
+            $ref: '#/components/schemas/betaMetric'
+          required: true
+        - in: path
+          name: named_sample_set
+          description: The named sample set that should be plotted
+          schema:
+            $ref: '#/components/schemas/namedSampleSet'
+          required: true
+      responses:
+        '200':
+          description: Successfully return Emperor Schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/emperorPCoA'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
 components:
   parameters:
     alphaMetric:
@@ -582,9 +613,65 @@ components:
     alphaMetric:
       type: string
       example: "faith_pd"
+    anyValue:
+      nullable: true
     betaMetric:
       type: string
       example: "unifrac"
+    coordinates:
+      description: >
+        2D array of coordinates
+      type: array
+      items:
+        type: array
+        items:
+          type: number
+      example:
+        - [-0.1776, 0.6011, -0.2033, -0.3368]
+        - [0.2561, 0.4013, -0.32037, 0.09316]
+    emperorDecomposition:
+      type: object
+      properties:
+        coordinates:
+          $ref: '#/components/schemas/coordinates'
+        percents_explained:
+          $ref: '#/components/schemas/percentsExplained'
+        sample_ids:
+          $ref: '#/components/schemas/sampleIdArray'
+    emperorPCoA:
+      type: object
+      description: >
+        # TODO
+      properties:
+        decomposition:
+          $ref: '#/components/schemas/emperorDecomposition'
+        metadata:
+          $ref: '#/components/schemas/metadata'
+        metadata_headers:
+          $ref: '#/components/schemas/metadataHeaders'
+    metadata:
+      description: >
+        2d array of metadata values
+      type: array
+      items:
+        type: array
+        items:
+          $ref: '#/components/schemas/metadataValue'
+        example:
+          - ["fecal", 0.7, 9, "30s", "Normal"]
+          - ["sebum", 20.4, null, "40s", "Overweight"]
+    metadataHeaders:
+      description: >
+        List of metadata column names
+      type: array
+      items:
+        type: string
+      example:
+        - "body-habitat"
+        - "latitude"
+        - "days_post_surgery"
+        - "age_cat"
+        - "bmi_cat"
     metadataQuery:
       # TODO try to make this a little more informative (challenging due to recursive definition)
       type: object
@@ -627,6 +714,11 @@ components:
           ],
           "valid": true
         }
+    metadataValue:
+      $ref: '#/components/schemas/anyValue'
+    namedSampleSet:
+      type: string
+      example: 'body-site'
     percentiles:
       type: array
       items:
@@ -636,6 +728,19 @@ components:
         nullable: true
       default: null
       nullable: true
+    percentsExplained:
+      description: >
+        Percent explained for axis labels
+      type: array
+      items:
+        type: number
+        minimum: 0
+        maximum: 100
+      example:
+        - 63.21
+        - 23.25
+        - 8.55
+        - 3.14
     relativeAbundance:
       type: number
       minimum: 0
@@ -643,6 +748,15 @@ components:
     sampleId:
       type: string
       example: "sample_15"
+    sampleIdArray:
+      description: >
+        List of sample identifiers
+      type: array
+      items:
+        $ref: '#/components/schemas/sampleId'
+      example:
+        - 'sample-1'
+        - 'sample-715'
     sampleIdList:
       type: object
       required:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -75,8 +75,119 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+    post:
+      operationId: microsetta_public_api.api.metadata.filter_sample_ids_query_builder
+      tags:
+        - Metadata
+      summary: Query samples associated with query
+      description: Query samples associated with query
+      parameters:
+        - in: query
+          name: taxonomy
+          description: Filter IDs to those present in the table associated with `taxonomy`
+          schema:
+            type: string
+            example: 'genus-level-taxonomy'
+        - in: query
+          name: alpha_metric
+          description: Filter IDs to those present in the data for `alpha_metric`
+          schema:
+            $ref: '#/components/schemas/alphaMetric'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/metadataQuery'
 
-  '/diversity/alpha/metrics/available':
+      responses:
+        '200':
+          description: Successfully returned sample ids
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/sampleIdList"
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
+  '/plotting/diversity/alpha/{alpha_metric}/percentiles-plot':
+    get:
+      operationId: microsetta_public_api.api.plotting.plot_alpha_filtered
+      tags:
+        - Plotting
+        - Diversity
+      summary: Get a Vega schema for alpha diversity cdf matching criteria
+      description: Get a Vega schema for alpha diversity cdf matching criteria
+      parameters:
+        - in: path
+          name: alpha_metric
+          description: Plot the data for samples using this metric
+          schema:
+            $ref: '#/components/schemas/alphaMetric'
+          required: true
+        - in: query
+          name: age_cat
+          schema:
+            type: string
+            example: '30s'
+        - in: query
+          name: bmi_cat
+          schema:
+            type: string
+            example: 'Normal'
+        - in: query
+          $ref: '#/components/parameters/percentiles'
+        - in: query
+          name: sample_id
+          schema:
+            $ref: '#/components/schemas/sampleId'
+      responses:
+        '200':
+          description: Successfully returned Vega JSON
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          $ref: '#/components/responses/404NotFound'
+    post:
+      operationId: microsetta_public_api.api.plotting.plot_alpha_filtered_json_query
+      tags:
+        - Plotting
+        - Diversity
+      summary: Get a Vega schema for alpha diversity cdf matching criteria
+      description: Get a Vega schema for alpha diversity cdf matching criteria
+      parameters:
+        - in: path
+          name: alpha_metric
+          description: Plot the data for samples using this metric
+          schema:
+            $ref: '#/components/schemas/alphaMetric'
+          required: true
+        - in: query
+          $ref: '#/components/parameters/percentiles'
+        - in: query
+          name: sample_id
+          schema:
+            $ref: '#/components/schemas/sampleId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/metadataQuery'
+      responses:
+        '200':
+          description: Successfully returned Vega JSON
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
+
+  '/diversity/metrics/alpha/available':
     get:
       operationId: microsetta_public_api.api.diversity.alpha.available_metrics_alpha
       tags:
@@ -159,14 +270,7 @@ paths:
           name: percentiles
           explode: false
           schema:
-            type: array
-            items:
-              type: number
-              minimum: 0
-              maximum: 100
-              nullable: true
-            default: null
-            nullable: true
+            $ref: '#/components/schemas/percentiles'
           required: false
           description: >
             Percentiles that should be returned. If not specified, then
@@ -262,6 +366,37 @@ paths:
         '400':
           description: >
             Either `summary_statistics`, `return_raw`, or both are required to be true.
+
+  '/plotting/diversity/beta/pcoa/{beta_metric}':
+    # TODO this should probably be more like '/plotting/diversity/beta/pcoa/{named_sample_set}
+    get:
+      operationId: microsetta_public_api.api.plotting.plot_beta
+      tags:
+        - Plotting
+        - Beta Diversity
+      summary: Get a Vega schema for PCOA plot
+      description: Get a Vega schema for PCOA plot
+      parameters:
+        - in: path
+          name: beta_metric
+          description: Plot the data for samples using this metric
+          schema:
+            $ref: '#/components/schemas/alphaMetric' # TODO change to betaMetric
+          required: true
+        - in: query
+          name: sample_id
+          schema:
+            $ref: '#/components/schemas/sampleId'
+      responses:
+        '200':
+          description: Successfully returned Vega JSON
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          $ref: '#/components/responses/404NotFound'
 
   '/taxonomy/available':
     get:
@@ -411,11 +546,69 @@ components:
         type: string
         example: "greengenes"
       required: true
+    percentiles:
+      name: percentiles
+      in: query
+      explode: false
+      schema:
+        $ref: '#/components/schemas/percentiles'
+      required: false
 
   schemas:
     alphaMetric:
       type: string
       example: "faith_pd"
+    metadataQuery:
+      # TODO try to make this a little more informative (challenging due to recursive definition)
+      type: object
+      additionalProperties: true
+      description: >
+        A jQuery [QueryBuilder](https://querybuilder.js.org/)-formatted query.
+      example:
+        {
+          "condition": "AND",
+          "rules": [
+          {
+            "id": "age_years",
+            "field": "age_years",
+            "type": "double",
+            "input": "number",
+            "operator": "less",
+            "value": 10.25
+          },
+          {
+            "condition": "OR",
+            "rules": [
+            {
+              "id": "bmi_cat",
+              "field": "bmi_cat",
+              "type": "integer",
+              "input": "select",
+              "operator": "equal",
+              "value": 2
+            },
+            {
+              "id": "bmi_cat",
+              "field": "bmi_cat",
+              "type": "integer",
+              "input": "select",
+              "operator": "equal",
+              "value": 1
+            }
+            ]
+          }
+          ],
+          "valid": true
+        }
+    percentiles:
+      type: array
+      items:
+        type: number
+        minimum: 0
+        maximum: 100
+        nullable: true
+      default: null
+      nullable: true
     relativeAbundance:
       type: number
       minimum: 0

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -36,6 +36,18 @@ paths:
             $ref: '#/components/responses/404NotFound'
 
   '/metadata/sample_ids':
+    parameters:
+      - in: query
+        name: taxonomy
+        description: Filter IDs to those present in the table associated with `taxonomy`
+        schema:
+          type: string
+          example: 'genus-level-taxonomy'
+      - in: query
+        name: alpha_metric
+        description: Filter IDs to those present in the data for `alpha_metric`
+        schema:
+          $ref: '#/components/schemas/alphaMetric'
     get:
       operationId: microsetta_public_api.api.metadata.filter_sample_ids
       tags:
@@ -53,17 +65,6 @@ paths:
           schema:
             type: string
             example: 'Normal'
-        - in: query
-          name: taxonomy
-          description: Filter IDs to those present in the table associated with `taxonomy`
-          schema:
-            type: string
-            example: 'genus-level-taxonomy'
-        - in: query
-          name: alpha_metric
-          description: Filter IDs to those present in the data for `alpha_metric`
-          schema:
-            $ref: '#/components/schemas/alphaMetric'
       responses:
         '200':
           description: Successfully returned sample ids
@@ -107,6 +108,19 @@ paths:
           $ref: '#/components/responses/404NotFound'
 
   '/plotting/diversity/alpha/{alpha_metric}/percentiles-plot':
+    parameters:
+      - in: path
+        name: alpha_metric
+        description: Plot the data for samples using this metric
+        schema:
+          $ref: '#/components/schemas/alphaMetric'
+        required: true
+      - in: query
+        $ref: '#/components/parameters/percentiles'
+      - in: query
+        name: sample_id
+        schema:
+          $ref: '#/components/schemas/sampleId'
     get:
       operationId: microsetta_public_api.api.plotting.plot_alpha_filtered
       tags:
@@ -115,12 +129,6 @@ paths:
       summary: Get a Vega schema for alpha diversity cdf matching criteria
       description: Get a Vega schema for alpha diversity cdf matching criteria
       parameters:
-        - in: path
-          name: alpha_metric
-          description: Plot the data for samples using this metric
-          schema:
-            $ref: '#/components/schemas/alphaMetric'
-          required: true
         - in: query
           name: age_cat
           schema:
@@ -131,12 +139,6 @@ paths:
           schema:
             type: string
             example: 'Normal'
-        - in: query
-          $ref: '#/components/parameters/percentiles'
-        - in: query
-          name: sample_id
-          schema:
-            $ref: '#/components/schemas/sampleId'
       responses:
         '200':
           description: Successfully returned Vega JSON
@@ -154,19 +156,6 @@ paths:
         - Alpha Diversity
       summary: Get a Vega schema for alpha diversity cdf matching criteria
       description: Get a Vega schema for alpha diversity cdf matching criteria
-      parameters:
-        - in: path
-          name: alpha_metric
-          description: Plot the data for samples using this metric
-          schema:
-            $ref: '#/components/schemas/alphaMetric'
-          required: true
-        - in: query
-          $ref: '#/components/parameters/percentiles'
-        - in: query
-          name: sample_id
-          schema:
-            $ref: '#/components/schemas/sampleId'
       requestBody:
         content:
           application/json:

--- a/microsetta_public_api/api/plotting.py
+++ b/microsetta_public_api/api/plotting.py
@@ -1,0 +1,12 @@
+def plot_alpha_filtered(alpha_metric, age_cat=None, bmi_cat=None,
+                        percentiles=None, sample_id=None):
+    raise NotImplementedError()
+
+
+def plot_alpha_filtered_json_query(body, alpha_metric, percentiles=None,
+                                   sample_id=None):
+    raise NotImplementedError()
+
+
+def plot_beta(beta_metric, named_sample_set, sample_id=None):
+    raise NotImplementedError()

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -696,7 +696,8 @@ class BetaDiversityTests(FlaskTests):
             _, self.client = self.build_app_test_client()
 
         response = self.client.get(
-            '/api/diversity/beta/pcoa/contains/unifrac/body-site/sample-12'
+            '/api/diversity/beta/pcoa/contains/unifrac/body-site'
+            '?sample_id=sample-12'
         )
 
         self.assertStatusCode(200, response)
@@ -714,7 +715,8 @@ class BetaDiversityTests(FlaskTests):
             _, self.client = self.build_app_test_client()
 
         response = self.client.get(
-            '/api/diversity/beta/pcoa/contains/unifrac/body-site/sample-12'
+            '/api/diversity/beta/pcoa/contains/unifrac/body-site'
+            '?sample_id=sample-12'
         )
 
         self.assertStatusCode(404, response)

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -696,7 +696,7 @@ class BetaDiversityTests(FlaskTests):
             _, self.client = self.build_app_test_client()
 
         response = self.client.get(
-            '/api/diversity/beta/pcoa/contains/unifrac/body-site'
+            '/api/diversity/beta/unifrac/pcoa/body-site/contains'
             '?sample_id=sample-12'
         )
 
@@ -715,7 +715,7 @@ class BetaDiversityTests(FlaskTests):
             _, self.client = self.build_app_test_client()
 
         response = self.client.get(
-            '/api/diversity/beta/pcoa/contains/unifrac/body-site'
+            '/api/diversity/beta/unifrac/pcoa/body-site/contains'
             '?sample_id=sample-12'
         )
 
@@ -1068,7 +1068,7 @@ class PlottingTests(FlaskTests):
             _, self.client = self.build_app_test_client()
 
         response = self.client.get(
-            "/api/plotting/diversity/beta/pcoa/unifrac/body-site"
+            "/api/plotting/diversity/beta/unifrac/pcoa/body-site/vega"
             "?sample_id=10377.12",
         )
         self.assertStatusCode(200, response)
@@ -1090,7 +1090,7 @@ class PlottingTests(FlaskTests):
             _, self.client = self.build_app_test_client()
 
         response = self.client.get(
-            "/api/plotting/diversity/beta/pcoa/unifrac/body-site"
+            "/api/plotting/diversity/beta/unifrac/pcoa/body-site/vega"
             "?sample_id=10377.12",
         )
         self.assertStatusCode(404, response)
@@ -1139,7 +1139,7 @@ class EmperorTests(FlaskTests):
             _, self.client = self.build_app_test_client()
 
         response = self.client.get(
-            '/api/emperor/pcoa/unifrac/body-habitat'
+            '/api/plotting/diversity/beta/unifrac/pcoa/body-habitat/emperor'
         )
 
         self.assertStatusCode(200, response)
@@ -1159,7 +1159,7 @@ class EmperorTests(FlaskTests):
             _, self.client = self.build_app_test_client()
 
         response = self.client.get(
-            '/api/emperor/pcoa/unifrac/body-habitat'
+            '/api/plotting/diversity/beta/unifrac/pcoa/body-habitat/emperor'
         )
 
         self.assertStatusCode(404, response)

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -243,6 +243,118 @@ class MetadataSampleIdsTests(FlaskTests):
         self.assertCountEqual(obs['sample_ids'], exp_ids)
         self.mock_method.assert_called_with()
 
+    def test_metadata_sample_ids_post_query_builder(self):
+        with self.app_context(), patch('microsetta_public_api.api.metadata'
+                                       '.filter_sample_ids_query_builder') as \
+                mock_method:
+            mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                    'sample-2',
+                ],
+            })
+            _, self.client = self.build_app_test_client()
+
+        request_body = \
+            {
+                "condition": "AND",
+                "rules": [
+                    {
+                        "id": "age_years",
+                        "field": "age_years",
+                        "type": "double",
+                        "input": "number",
+                        "operator": "less",
+                        "value": 10.25
+                    },
+                ],
+                "valid": True
+            }
+
+        response = self.client.post(
+            "/api/metadata/sample_ids",
+            content_type='application/json',
+            data=json.dumps(request_body)
+        )
+        exp_ids = ['sample-1', 'sample-2']
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+        mock_method.assert_called_with(body=request_body)
+
+    def test_metadata_sample_ids_post_query_builder_extra_args(self):
+        with self.app_context(), patch('microsetta_public_api.api.metadata'
+                                       '.filter_sample_ids_query_builder') as \
+                mock_method:
+            mock_method.return_value = jsonify({
+                'sample_ids': [
+                    'sample-1',
+                    'sample-2',
+                ],
+            })
+            _, self.client = self.build_app_test_client()
+
+        request_body = \
+            {
+                "condition": "AND",
+                "rules": [
+                    {
+                        "id": "age_years",
+                        "field": "age_years",
+                        "type": "double",
+                        "input": "number",
+                        "operator": "less",
+                        "value": 10.25
+                    },
+                ],
+                "valid": True
+            }
+
+        response = self.client.post(
+            "/api/metadata/sample_ids?taxonomy=gg&alpha_metric=faith-pd",
+            content_type='application/json',
+            data=json.dumps(request_body)
+        )
+        exp_ids = ['sample-1', 'sample-2']
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+        mock_method.assert_called_with(body=request_body, taxonomy='gg',
+                                       alpha_metric='faith-pd')
+
+    def test_metadata_sample_ids_post_query_builder_404(self):
+        with self.app_context(), patch('microsetta_public_api.api.metadata'
+                                       '.filter_sample_ids_query_builder') as \
+                mock_method:
+            mock_method.return_value = jsonify(text='Not found', code=404), 404
+            _, self.client = self.build_app_test_client()
+
+        request_body = \
+            {
+                "condition": "AND",
+                "rules": [
+                    {
+                        "id": "age_years",
+                        "field": "age_years",
+                        "type": "double",
+                        "input": "number",
+                        "operator": "less",
+                        "value": 10.25
+                    },
+                ],
+                "valid": True
+            }
+
+        response = self.client.post(
+            "/api/metadata/sample_ids",
+            content_type='application/json',
+            data=json.dumps(request_body)
+        )
+        self.assertStatusCode(404, response)
+        mock_method.assert_called_with(body=request_body)
+
 
 class AlphaDiversityTestCase(FlaskTests):
 
@@ -575,6 +687,44 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         self.assertEqual(response.status_code, 500)
 
 
+class BetaDiversityTests(FlaskTests):
+
+    def test_pcoa_contains(self):
+        method = 'microsetta_public_api.api.diversity.beta.pcoa_contains'
+        with self.app_context(), patch(method) as mock_method:
+            mock_method.return_value = True
+            _, self.client = self.build_app_test_client()
+
+        response = self.client.get(
+            '/api/diversity/beta/pcoa/contains/unifrac/body-site/sample-12'
+        )
+
+        self.assertStatusCode(200, response)
+        self.assertEqual(json.loads(response.data), True)
+        mock_method.assert_called_with(
+            beta_metric='unifrac',
+            named_sample_set='body-site',
+            sample_id='sample-12',
+        )
+
+    def test_pcoa_contains_404(self):
+        method = 'microsetta_public_api.api.diversity.beta.pcoa_contains'
+        with self.app_context(), patch(method) as mock_method:
+            mock_method.return_value = jsonify(text='Sample not found'), 404
+            _, self.client = self.build_app_test_client()
+
+        response = self.client.get(
+            '/api/diversity/beta/pcoa/contains/unifrac/body-site/sample-12'
+        )
+
+        self.assertStatusCode(404, response)
+        mock_method.assert_called_with(
+            beta_metric='unifrac',
+            named_sample_set='body-site',
+            sample_id='sample-12',
+        )
+
+
 class TaxonomyResourcesAPITests(FlaskTests):
 
     def setUp(self):
@@ -767,3 +917,183 @@ class TaxonomyDataTableTests(FlaskTests):
             data=json.dumps({'sample_ids': ['sample1', 'sample2']})
         )
         self.assertEqual(404, response.status_code)
+
+
+class PlottingTests(FlaskTests):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sample_vega_schema = {
+            "data": {"url": "data/population.json"},
+            "transform": [{
+                "filter": "datum.year == 2000"
+            }],
+            "mark": "bar",
+            "encoding": {
+                "x": {
+                    "aggregate": "sum",
+                    "field": "people",
+                    "type": "quantitative",
+                    "axis": {"title": "population"}
+                }
+            },
+            "config": {"view": {"step": 15}}
+        }
+
+    def test_alpha_percentiles_plot_get(self):
+        method = 'microsetta_public_api.api.plotting.plot_alpha_filtered'
+        with self.app_context(), patch(method) as mock_method:
+            mock_method.return_value = jsonify(
+                self.sample_vega_schema
+            ), 200
+            _, self.client = self.build_app_test_client()
+
+        response = self.client.get(
+            "/api/plotting/diversity/alpha/faith-pd/percentiles-plot"
+            "?age_cat=30s&bmi_cat=Normal&percentiles=1,2,3,5"
+            "&sample_id=10377.12"
+        )
+        self.assertStatusCode(200, response)
+        self.assertDictEqual(self.sample_vega_schema,
+                             json.loads(response.data))
+        mock_method.assert_called_with(alpha_metric='faith-pd',
+                                       age_cat='30s',
+                                       bmi_cat='Normal',
+                                       percentiles=[1, 2, 3, 5],
+                                       sample_id='10377.12',
+                                       )
+
+    def test_alpha_percentiles_plot_get_404(self):
+        method = 'microsetta_public_api.api.plotting.plot_alpha_filtered'
+        with self.app_context(), patch(method) as mock_method:
+            mock_method.return_value = jsonify(
+                text='not found', code=404,
+            ), 404
+            _, self.client = self.build_app_test_client()
+
+        response = self.client.get(
+            "/api/plotting/diversity/alpha/faith-pd/percentiles-plot"
+            "?age_cat=30s&bmi_cat=Normal&percentiles=1,2,3,5"
+            "&sample_id=10377.12"
+        )
+        self.assertStatusCode(404, response)
+
+    def test_alpha_percentiles_plot_post(self):
+        method = 'microsetta_public_api.api.plotting' \
+                 '.plot_alpha_filtered_json_query'
+        with self.app_context(), patch(method) as mock_method:
+            mock_method.return_value = jsonify(
+                self.sample_vega_schema
+            ), 200
+            _, self.client = self.build_app_test_client()
+
+        request_body = \
+            {
+                "condition": "AND",
+                "rules": [
+                    {
+                        "id": "age_years",
+                        "field": "age_years",
+                        "type": "double",
+                        "input": "number",
+                        "operator": "less",
+                        "value": 10.25
+                    },
+                ],
+                "valid": True
+            }
+
+        response = self.client.post(
+            "/api/plotting/diversity/alpha/faith-pd/percentiles-plot"
+            "?&percentiles=1,2,3,5&sample_id=10377.12",
+            content_type='application/json',
+            data=json.dumps(request_body)
+        )
+        self.assertStatusCode(200, response)
+        self.assertDictEqual(self.sample_vega_schema,
+                             json.loads(response.data))
+        mock_method.assert_called_with(alpha_metric='faith-pd',
+                                       body=request_body,
+                                       percentiles=[1, 2, 3, 5],
+                                       sample_id='10377.12',
+                                       )
+
+    def test_alpha_percentiles_plot_post_404(self):
+        method = 'microsetta_public_api.api.plotting' \
+                 '.plot_alpha_filtered_json_query'
+        with self.app_context(), patch(method) as mock_method:
+            mock_method.return_value = jsonify(
+                text='not found', code=404
+            ), 404
+            _, self.client = self.build_app_test_client()
+
+        request_body = \
+            {
+                "condition": "AND",
+                "rules": [
+                    {
+                        "id": "age_years",
+                        "field": "age_years",
+                        "type": "double",
+                        "input": "number",
+                        "operator": "less",
+                        "value": 10.25
+                    },
+                ],
+                "valid": True
+            }
+
+        response = self.client.post(
+            "/api/plotting/diversity/alpha/faith-pd/percentiles-plot"
+            "?&percentiles=1,2,3,5&sample_id=10377.12",
+            content_type='application/json',
+            data=json.dumps(request_body)
+        )
+        self.assertStatusCode(404, response)
+        mock_method.assert_called_with(alpha_metric='faith-pd',
+                                       body=request_body,
+                                       percentiles=[1, 2, 3, 5],
+                                       sample_id='10377.12',
+                                       )
+
+    def test_beta_vega_plot(self):
+        method = 'microsetta_public_api.api.plotting.plot_beta'
+        with self.app_context(), patch(method) as mock_method:
+            mock_method.return_value = jsonify(
+                self.sample_vega_schema
+            )
+            _, self.client = self.build_app_test_client()
+
+        response = self.client.get(
+            "/api/plotting/diversity/beta/pcoa/unifrac/body-site"
+            "?sample_id=10377.12",
+        )
+        self.assertStatusCode(200, response)
+        self.assertDictEqual(self.sample_vega_schema,
+                             json.loads(response.data))
+        mock_method.assert_called_with(
+            beta_metric='unifrac',
+            named_sample_set='body-site',
+            sample_id='10377.12',
+        )
+
+    def test_beta_vega_plot_404(self):
+        method = 'microsetta_public_api.api.plotting.plot_beta'
+        with self.app_context(), patch(method) as mock_method:
+            mock_method.return_value = jsonify(
+                text='Not found',
+                code=404
+            ), 404
+            _, self.client = self.build_app_test_client()
+
+        response = self.client.get(
+            "/api/plotting/diversity/beta/pcoa/unifrac/body-site"
+            "?sample_id=10377.12",
+        )
+        self.assertStatusCode(404, response)
+        mock_method.assert_called_with(
+            beta_metric='unifrac',
+            named_sample_set='body-site',
+            sample_id='10377.12',
+        )


### PR DESCRIPTION
This PR adds the following endpoints in the API spec (with corresponding tests), which will be helpful for a participant interface:

- `POST /metadata/sample_ids`
    - method: `microsetta_public_api.api.metadata.filter_sample_ids_query_builder`
- `GET /plotting/diversity/alpha/{alpha_metric}/percentiles-plot`
    - method: `microsetta_public_api.api.plotting.plot_alpha_filtered`
- `POST /plotting/diversity/alpha/{alpha_metric}/percentiles-plot`
    - method: `microsetta_public_api.api.plotting.plot_alpha_filtered_json_query`
- `GET /diversity/beta/pcoa/contains/{beta_metric}/{named_sample_set}/{sample_id}`
    - method: `microsetta_public_api.api.diversity.beta.pcoa_contains`
- `GET /plotting/diversity/beta/pcoa/{beta_metric}/{named_sample_set}`
    - method: `microsetta_public_api.api.plotting.plot_beta`
- `GET /emperor/pcoa/{beta_metric}/{named_sample_set}?{sample_id}`
    - method: `microsetta_public_api.api.emperor.plot_pcoa`