### PR TITLE
Add querybuilder metadata implementation

### DIFF
--- a/microsetta_public_api/api/metadata.py
+++ b/microsetta_public_api/api/metadata.py
@@ -38,7 +38,23 @@ def filter_sample_ids(taxonomy=None, alpha_metric=None, **kwargs):
 
 
 def filter_sample_ids_query_builder(body, taxonomy=None, alpha_metric=None):
-    raise NotImplementedError()
+    query = body
+    repo = MetadataRepo()
+    # TODO probably want some form of validation here
+    matching_ids = repo.sample_id_matches(query)
+    matching_ids, error_code, error_response = _filter_matching_ids(
+        matching_ids, TaxonomyRepo, 'resources', taxonomy, 'resource',
+    )
+
+    matching_ids, error_code, error_response = _filter_matching_ids(
+        matching_ids, AlphaRepo, 'available_metrics', alpha_metric,
+        'metric', error_response=error_response, error_code=error_code,
+    )
+
+    if error_response:
+        return error_response, error_code
+
+    return jsonify(sample_ids=matching_ids), 200
 
 
 def _filter_matching_ids(matching_ids, repo, category, value, resource_type,

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -151,6 +151,7 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+
   '/diversity/alpha/metrics/available':
     get:
       operationId: microsetta_public_api.api.diversity.alpha.available_metrics_alpha

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -151,7 +151,6 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
-
   '/diversity/alpha/metrics/available':
     get:
       operationId: microsetta_public_api.api.diversity.alpha.available_metrics_alpha

--- a/microsetta_public_api/api/tests/implementation_tests/test_metadata.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_metadata.py
@@ -177,7 +177,7 @@ class MetadataImplementationTests(MockedJsonifyTestCase):
         with patch.object(MetadataRepo, 'sample_id_matches') as mock_matches, \
                 patch('microsetta_public_api.repo._metadata_repo.MetadataRepo.'
                       'categories', new_callable=PropertyMock) as \
-                        mock_categories:
+                mock_categories:
             mock_matches.return_value = ['sample-1', 'sample-3']
             mock_categories.return_value = ['age_cat']
             response, code = filter_sample_ids_query_builder(
@@ -192,7 +192,7 @@ class MetadataImplementationTests(MockedJsonifyTestCase):
         with patch.object(MetadataRepo, 'sample_id_matches') as mock_matches, \
                 patch('microsetta_public_api.repo._metadata_repo.MetadataRepo.'
                       'categories', new_callable=PropertyMock) as \
-                        mock_categories, \
+                mock_categories, \
                 patch('microsetta_public_api.api.metadata'
                       '.TaxonomyRepo.exists') as mock_exists, \
                 patch('microsetta_public_api.api.metadata'

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -47,6 +47,20 @@ class MetadataIntegrationTests(IntegrationTests):
         config.resources.update({'metadata': self.metadata_path})
         resources.update(config.resources)
 
+        self.sample_querybuilder = {
+            "condition": "AND",
+            "rules": [
+                {
+                    "id": "age_cat",
+                    "field": "age_cat",
+                    "type": "string",
+                    "input": "select",
+                    "operator": "equal",
+                    "value": "30s"
+                },
+            ]
+        }
+
     def test_metadata_category_values_returns_string_array(self):
         exp = ['30s', '40s', '50s']
         response = self.client.get(
@@ -73,6 +87,83 @@ class MetadataIntegrationTests(IntegrationTests):
         exp_ids = ['sample-1', 'sample-4']
         response = self.client.get(
             "/api/metadata/sample_ids?age_cat=30s&bmi_cat=normal")
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+
+    def test_metadata_sample_ids_returns_simple_post(self):
+        exp_ids = ['sample-1', 'sample-4']
+        response = self.client.post(
+            "/api/metadata/sample_ids",
+            content_type='application/json',
+            data=json.dumps({
+                "condition": "AND",
+                "rules": [
+                    {
+                        "id": "age_cat",
+                        "field": "age_cat",
+                        "type": "string",
+                        "input": "select",
+                        "operator": "equal",
+                        "value": "30s"
+                    },
+                    {
+                        "id": "bmi_cat",
+                        "field": "bmi_cat",
+                        "type": "string",
+                        "input": "select",
+                        "operator": "equal",
+                        "value": "normal"
+                    },
+                ]
+            })
+        )
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['sample_ids'], obs.keys())
+        self.assertCountEqual(obs['sample_ids'], exp_ids)
+
+    def test_metadata_sample_ids_returns_nested_post(self):
+        exp_ids = ['sample-1', 'sample-4', 'sample-5']
+        response = self.client.post(
+            "/api/metadata/sample_ids",
+            content_type='application/json',
+            data=json.dumps({
+                "condition": "AND",
+                "rules": [
+                    {
+                        "id": "age_cat",
+                        "field": "age_cat",
+                        "type": "string",
+                        "input": "select",
+                        "operator": "equal",
+                        "value": "30s"
+                    },
+                    {
+                        "condition": "OR",
+                        "rules": [
+                            {
+                                "id": "bmi_cat",
+                                "field": "bmi_cat",
+                                "type": "string",
+                                "input": "select",
+                                "operator": "equal",
+                                "value": "normal"
+                            },
+                            {
+                                "id": "bmi_cat",
+                                "field": "bmi_cat",
+                                "type": "string",
+                                "input": "select",
+                                "operator": "equal",
+                                "value": "not"
+                            },
+                        ],
+                    },
+                ]
+            })
+        )
         self.assertStatusCode(200, response)
         obs = json.loads(response.data)
         self.assertCountEqual(['sample_ids'], obs.keys())


### PR DESCRIPTION
Depends on #37 

This PR adds the underlying functionality and associated unit tests for processing sample ID queries on metadata, received in the format of [jQuery QueryBuilder](https://querybuilder.js.org/). This will be helpful for adding nice query boxes, e.g below, to a user interface:

![Screen Shot 2020-07-17 at 12 25 29 PM](https://user-images.githubusercontent.com/19470970/87823652-a292d400-c828-11ea-96c3-b7fd065bc50e.png)
