### PR TITLE
Use scipy.sparse on empty variance construction

### DIFF
--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -6,6 +6,7 @@ import skbio
 import biom
 import numpy as np
 import pandas as pd
+import scipy.sparse as ss
 
 from microsetta_public_api.exceptions import DisjointError, UnknownID
 from microsetta_public_api.utils import DataTable
@@ -114,7 +115,9 @@ class Taxonomy(ModelBase):
         self._ranks = table.rankdata(inplace=False)
 
         if variances is None:
-            self._variances = biom.Table(np.zeros(self._table.shape),
+            empty = ss.csr_matrix((len(self._table.ids(axis='observation')),
+                                   len(self._table.ids())), dtype=float)
+            self._variances = biom.Table(empty,
                                          self._table.ids(axis='observation'),
                                          self._table.ids())
         else:


### PR DESCRIPTION
Fixes #42 

A major source of the slowdown and memory consumption was the creation of `_variances` in the taxonomy model, which used a full dense `np.array` of zeros to create a `biom.Table`. This can easily be replaced by a sparse equivalent, which reduces time/memory. 