### PR TITLE
Adds CORS with flask-cors, you need this for local testing.

### DIFF
--- a/ci/test-env.yml
+++ b/ci/test-env.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - python
   - flask
+  - flask-cors
   - scikit-bio
   - biom-format
   - pandas

--- a/microsetta_public_api/server.py
+++ b/microsetta_public_api/server.py
@@ -4,6 +4,7 @@ from microsetta_public_api import config
 from microsetta_public_api.resources import resources
 
 import connexion
+from flask_cors import CORS
 
 
 def build_app(resources_config_json=None):
@@ -22,6 +23,8 @@ def build_app(resources_config_json=None):
     app_file = resource_filename('microsetta_public_api.api',
                                  'microsetta_public_api.yml')
     app.add_api(app_file, validate_responses=True)
+
+    CORS(app.app)
 
     return app
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         'connexion[swagger-ui]',
         'flask',
+        'flask-cors',
         'pyyaml',
         'pandas',
         'numpy',


### PR DESCRIPTION
We found in local testing that we need the api to send back Access-Control-Allow-Origin headers, flask-cors does this.  