### PR TITLE
More closely mirror config handling for other microsetta- projects

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include versioneer.py
 include microsetta_public_api/_version.py
+
+graft microsetta_public_api

--- a/microsetta_public_api/config.py
+++ b/microsetta_public_api/config.py
@@ -6,7 +6,7 @@ from microsetta_public_api.exceptions import ConfigurationError
 # See: https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package # noqa
 
 PACKAGE_NAME = __name__.split('.')[0]
-CONFIG_FILE = "server_config.json"
+CONFIG_FILE = os.getenv("MPUBAPI_CFG", "server_config.json")
 
 try:
     import importlib.resources as pkg_resources

--- a/microsetta_public_api/config.py
+++ b/microsetta_public_api/config.py
@@ -1,5 +1,22 @@
 import os
+import json
 from microsetta_public_api.exceptions import ConfigurationError
+
+# NOTE: importlib replaces setuptools' pkg_resources as of Python 3.7
+# See: https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package # noqa
+
+PACKAGE_NAME = __name__.split('.')[0]
+CONFIG_FILE = "server_config.json"
+
+try:
+    import importlib.resources as pkg_resources
+    with pkg_resources.open_text(PACKAGE_NAME, CONFIG_FILE) as fp:
+        SERVER_CONFIG = json.load(fp)
+
+except ImportError:
+    import pkg_resources
+    content = pkg_resources.resource_string(PACKAGE_NAME, CONFIG_FILE)
+    SERVER_CONFIG = json.loads(content)
 
 
 class ResourcesConfig(dict):

--- a/microsetta_public_api/server.py
+++ b/microsetta_public_api/server.py
@@ -1,4 +1,3 @@
-import json
 from pkg_resources import resource_filename
 from microsetta_public_api.config import (SERVER_CONFIG,
                                           resources as config_resources)

--- a/microsetta_public_api/server.py
+++ b/microsetta_public_api/server.py
@@ -1,6 +1,7 @@
 import json
 from pkg_resources import resource_filename
-from microsetta_public_api import config
+from microsetta_public_api.config import (SERVER_CONFIG,
+                                          resources as config_resources)
 from microsetta_public_api.resources import resources
 
 import connexion
@@ -14,9 +15,9 @@ def build_app(resource_updates=None):
     # microsetta.config.resources, this config can be updated by a json file
     # passed to `build_app`.
     if resource_updates is not None:
-        config.resources.update(resource_updates)
+        config_resources.update(resource_updates)
 
-        resources.update(config.resources)
+        resources.update(config_resources)
 
     app_file = resource_filename('microsetta_public_api.api',
                                  'microsetta_public_api.yml')
@@ -28,24 +29,17 @@ def build_app(resource_updates=None):
 
 
 if __name__ == "__main__":
-    import sys
-    config_fp = sys.argv[1] if len(sys.argv) > 1 else None
+    resource_config = SERVER_CONFIG.get('resources', {})
+    port = SERVER_CONFIG['port']
+    debug = SERVER_CONFIG['debug']
+    use_test_database = SERVER_CONFIG['use_test_database']
 
-    if config_fp is None:
-        resource_config = None
-        server_config = {}
-    else:
-        with open(config_fp) as fp:
-            server_config = json.load(fp)
-        resource_config = server_config.get('resources', None)
-
-    port = server_config.get('port', 8084)
-    if config_fp:
-        app = build_app(resource_updates=resource_config)
-        app.run(port=port, debug=True)
-    else:
+    if use_test_database:
         # import TestDatabase here to avoid circular import
         from microsetta_public_api.utils.testing import TestDatabase
         with TestDatabase():
             app = build_app()
             app.run(port=port, debug=True)
+    else:
+        app = build_app(resource_updates=resource_config)
+        app.run(port=port, debug=debug)

--- a/microsetta_public_api/server_config.json
+++ b/microsetta_public_api/server_config.json
@@ -1,0 +1,6 @@
+{
+    "debug": true,
+    "port": 8084,
+    "use_test_database": true,
+    "resources": {}
+}

--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,9 @@ setup(
         'scikit-bio',
         'altair',
     ],
+    package_data={'microsetta_public_api':
+                  [
+                     'api/microsetta_public_api.yaml',
+                     'server_config.json'
+                  ]},
 )


### PR DESCRIPTION
Now using a similar config mechanism to the other microsetta- projects. This is helpful particularly for deployments via gunicorn where (on the other projects) we are not utilizing `sys.argv`