### PR TITLE
run indirection

### DIFF
--- a/microsetta_public_api/server.py
+++ b/microsetta_public_api/server.py
@@ -7,16 +7,16 @@ import connexion
 from flask_cors import CORS
 
 
-def build_app(resource_updates=None):
+def build_app():
     app = connexion.FlaskApp(__name__)
+
+    resource_config = SERVER_CONFIG.get('resources', {})
 
     # default configuration for resources is provided in
     # microsetta.config.resources, this config can be updated by a json file
     # passed to `build_app`.
-    if resource_updates is not None:
-        config_resources.update(resource_updates)
-
-        resources.update(config_resources)
+    config_resources.update(resource_config)
+    resources.update(config_resources)
 
     app_file = resource_filename('microsetta_public_api.api',
                                  'microsetta_public_api.yml')
@@ -27,18 +27,21 @@ def build_app(resource_updates=None):
     return app
 
 
-if __name__ == "__main__":
-    resource_config = SERVER_CONFIG.get('resources', {})
-    port = SERVER_CONFIG['port']
-    debug = SERVER_CONFIG['debug']
-    use_test_database = SERVER_CONFIG['use_test_database']
+def run(app):
+    app.run(
+        port=SERVER_CONFIG['port'],
+        debug=SERVER_CONFIG['debug'],
+    )
 
+
+if __name__ == "__main__":
+    use_test_database = SERVER_CONFIG['use_test_database']
     if use_test_database:
         # import TestDatabase here to avoid circular import
         from microsetta_public_api.utils.testing import TestDatabase
         with TestDatabase():
             app = build_app()
-            app.run(port=port, debug=True)
+            run(app)
     else:
-        app = build_app(resource_updates=resource_config)
-        app.run(port=port, debug=debug)
+        app = build_app()
+        run(app)

--- a/microsetta_public_api/server_config.json
+++ b/microsetta_public_api/server_config.json
@@ -1,6 +1,6 @@
 {
     "debug": true,
     "port": 8084,
-    "use_test_database": true,
+    "use_test_database": false,
     "resources": {}
 }

--- a/microsetta_public_api/tests/test_server.py
+++ b/microsetta_public_api/tests/test_server.py
@@ -7,8 +7,3 @@ class BuildServerTests(TempfileTestCase):
     def test_build_app(self):
         app = build_app()
         self.assertTrue(app)
-
-    def test_build_app_with_json(self):
-        test_dict = {'some_resource': 'some_value'}
-        app = build_app(resource_updates=test_dict)
-        self.assertTrue(app)


### PR DESCRIPTION
Resources are pulled directly from config on build_app, and `run` is now via an indirection. This is critical for the current deployment which does not use `__main__`