### PR TITLE
NEW add metadata query to alpha group

### DIFF
--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -33,14 +33,6 @@ def alpha_group(body, alpha_metric, summary_statistics=True,
             error=400, text='Either `summary_statistics`, `return_raw`, '
                             'or both are required to be true.'
             ), 400
-    if ('sample_ids' in body and 'metadata_query' in body) and \
-            'condition' not in body:
-        # give a bad request error here, because we need to know how to
-        #  resolve the sample IDs
-        return jsonify(
-            error=400, text='`condition` must be specified if both '
-                            '`sample_ids` and `metadata_query` are specified.'
-        )
 
     sample_ids = []
     alpha_repo = AlphaRepo()

--- a/microsetta_public_api/api/diversity/alpha.py
+++ b/microsetta_public_api/api/diversity/alpha.py
@@ -1,5 +1,6 @@
 from microsetta_public_api.models._alpha import Alpha
 from microsetta_public_api.repo._alpha_repo import AlphaRepo
+from microsetta_public_api.repo._metadata_repo import MetadataRepo
 from microsetta_public_api.utils import jsonify
 from microsetta_public_api.utils._utils import validate_resource, \
     check_missing_ids
@@ -32,12 +33,18 @@ def alpha_group(body, alpha_metric, summary_statistics=True,
             error=400, text='Either `summary_statistics`, `return_raw`, '
                             'or both are required to be true.'
             ), 400
+    if ('sample_ids' in body and 'metadata_query' in body) and \
+            'condition' not in body:
+        # give a bad request error here, because we need to know how to
+        #  resolve the sample IDs
+        return jsonify(
+            error=400, text='`condition` must be specified if both '
+                            '`sample_ids` and `metadata_query` are specified.'
+        )
 
-    sample_ids = body['sample_ids']
-
+    sample_ids = []
     alpha_repo = AlphaRepo()
-
-    # figure out if the user asked for a metric we have data on
+    # do the common checks
     available_metrics = alpha_repo.available_metrics()
     type_ = 'metric'
     missing_metric = validate_resource(available_metrics, alpha_metric,
@@ -45,13 +52,32 @@ def alpha_group(body, alpha_metric, summary_statistics=True,
     if missing_metric:
         return missing_metric
 
-    # make sure all of the data the samples the user asked for have values
-    # for the given metric
-    missing_ids = [id_ for id_ in sample_ids if
-                   not alpha_repo.exists(id_, alpha_metric)]
-    missing_ids_msg = check_missing_ids(missing_ids, alpha_metric, type_)
-    if missing_ids_msg:
-        return missing_ids_msg
+    if 'sample_ids' in body:
+        sample_ids = body['sample_ids']
+
+        # figure out if the user asked for a metric we have data on
+        # make sure all of the data the samples the user asked for have values
+        # for the given metric
+        missing_ids = [id_ for id_ in sample_ids if
+                       not alpha_repo.exists(id_, alpha_metric)]
+        missing_ids_msg = check_missing_ids(missing_ids, alpha_metric, type_)
+        if missing_ids_msg:
+            return missing_ids_msg
+
+    # find sample IDs matching the metadata query
+    if 'metadata_query' in body:
+        query = body['metadata_query']
+        metadata_repo = MetadataRepo()
+        matching_ids = metadata_repo.sample_id_matches(query)
+        matching_ids = [id_ for id_ in matching_ids if
+                        alpha_repo.exists(id_, alpha_metric)
+                        ]
+        if 'sample_ids' not in body:
+            sample_ids = matching_ids
+        elif body['condition'] == 'OR':
+            sample_ids = list(set(sample_ids) | set(matching_ids))
+        elif body['condition'] == 'AND':
+            sample_ids = list(set(sample_ids) & set(matching_ids))
 
     # retrieve the alpha diversity for each sample
     alpha_series = alpha_repo.get_alpha_diversity(sample_ids,

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -257,7 +257,12 @@ paths:
       tags:
         - Alpha Diversity
       summary: Query alpha diversity for a group of samples
-      description: Query alpha diversity for a group of samples
+      description: >
+        Query alpha diversity for a group of samples.
+        If `condition="AND"`, a group summary will be provided for those ID's matching both
+        `sample_ids` and `metadata_query`.
+        If `condition="OR"`, the summary will be provided for ID's matching either `sample_ids` or `metadata_query`.
+        '`condition` must be specified if both '`sample_ids` and `metadata_query` are specified.'
       parameters:
         - $ref: '#/components/parameters/alphaMetric'
         - in: query
@@ -288,21 +293,26 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                sample_ids:
-                  $ref: "#/components/schemas/sampleIdArray"
-                metadata_query:
-                  $ref: "#/components/schemas/metadataQuery"
-                condition:
-                  type: string
-                  enum:
-                    - "AND"
-                    - "OR"
-                  description: >
-                    If `"AND"`, a group summary will be provided for those ID's matching both
-                    `sample_ids` and `metadata_query`.
-                    If `"OR"`, the summary will be provided for ID's matching either `sample_ids` or `metadata_query`.
+              allOf:
+                - type: object
+                  properties:
+                    sample_ids:
+                      $ref: "#/components/schemas/sampleIdArray"
+                    metadata_query:
+                      $ref: "#/components/schemas/metadataQuery"
+                    condition:
+                      $ref: "#/components/schemas/ANDOR"
+              not:
+                type: object
+                additionalProperties: false
+                required:
+                  - sample_ids
+                  - metadata_query
+                properties:
+                  sample_ids:
+                    $ref: "#/components/schemas/sampleIdArray"
+                  metadata_query:
+                    $ref: "#/components/schemas/metadataQuery"
       responses:
         '200':
           description: Successfuly return alpha diversity information
@@ -673,6 +683,11 @@ components:
       example: "faith_pd"
     anyValue:
       nullable: true
+    ANDOR:
+      type: string
+      enum:
+        - "AND"
+        - "OR"
     betaMetric:
       type: string
       example: "unifrac"

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -247,7 +247,21 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/sampleIdList"
+              type: object
+              properties:
+                sample_ids:
+                  $ref: "#/components/schemas/sampleIdArray"
+                metadata_query:
+                  $ref: "#/components/schemas/metadataQuery"
+                condition:
+                  type: string
+                  enum:
+                    - "AND"
+                    - "OR"
+                  description: >
+                    If `"AND"`, a group summary will be provided for those ID's matching both
+                    `sample_ids` and `metadata_query`.
+                    If `"OR"`, the summary will be provided for ID's matching either `sample_ids` or `metadata_query`.
       responses:
         '200':
           description: Successfuly return alpha diversity information

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -503,6 +503,93 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
         self.assertDictEqual(exp, obs)
         self.assertEqual(response.status_code, 200)
 
+    def test_alpha_diversity_group_api_with_metadata_query_and_ids(self):
+        exp = {
+            'alpha_metric': 'observed_otus',
+            'alpha_diversity': {'sample-foo-bar': 8.25,
+                                'sample-baz-bat': 9.01,
+                                }
+        }
+
+        with self.app_context():
+            self.mock_method.return_value = jsonify(exp), 200
+
+        _, self.client = self.build_app_test_client()
+
+        request_content = {
+            'sample_ids': ['sample-foo-bar',
+                           'sample-baz-bat'],
+            'metadata_query':
+                {
+                    "condition": "AND",
+                    "rules": [
+                        {
+                            "id": "age_years",
+                            "field": "age_years",
+                            "type": "double",
+                            "input": "number",
+                            "operator": "less",
+                            "value": 10.25
+                        },
+                    ],
+                    "valid": True
+                },
+            'condition': "OR"
+        }
+
+        response = self.client.post(
+            '/results-api/diversity/alpha/group/observed_otus',
+            content_type='application/json',
+            data=json.dumps(request_content)
+        )
+
+        obs = json.loads(response.data)
+
+        self.assertDictEqual(exp, obs)
+        self.assertEqual(response.status_code, 200)
+
+    def test_alpha_diversity_group_api_with_metadata_query_no_ids(self):
+        exp = {
+            'alpha_metric': 'observed_otus',
+            'alpha_diversity': {'sample-foo-bar': 8.25,
+                                'sample-baz-bat': 9.01,
+                                }
+        }
+
+        with self.app_context():
+            self.mock_method.return_value = jsonify(exp), 200
+
+        _, self.client = self.build_app_test_client()
+
+        request_content = {
+            'metadata_query':
+                {
+                    "condition": "AND",
+                    "rules": [
+                        {
+                            "id": "age_years",
+                            "field": "age_years",
+                            "type": "double",
+                            "input": "number",
+                            "operator": "less",
+                            "value": 10.25
+                        },
+                    ],
+                    "valid": True
+                },
+        }
+
+        response = self.client.post(
+            '/results-api/diversity/alpha/group/observed_otus',
+            content_type='application/json',
+            data=json.dumps(request_content)
+        )
+
+        obs = json.loads(response.data)
+
+        self.assertDictEqual(exp, obs)
+        self.assertEqual(response.status_code, 200)
+
     def test_alpha_diversity_group_unknown_metric_api(self):
 
         available_metrics = ['metric1', 'metric2']

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -635,7 +635,7 @@ class AlphaIntegrationTests(IntegrationTests):
 
     def test_exists_single_404(self):
         response = self.client.get('/results-api/diversity/alpha/exists/'
-                                   'shannon?sample_id=sample-foo-bar')
+                                   'dne-metric?sample_id=sample-foo-bar')
 
         self.assertStatusCode(404, response)
 
@@ -652,7 +652,7 @@ class AlphaIntegrationTests(IntegrationTests):
 
     def test_exists_group_404(self):
         response = self.client.post(
-            '/results-api/diversity/alpha/exists/shannon',
+            '/results-api/diversity/alpha/exists/dne-metric',
             data=json.dumps(['sample-foo-bar', 'sample-dne', 's3']),
             content_type='application/json',
         )

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -526,6 +526,7 @@ class AlphaIntegrationTests(IntegrationTests):
         super().setUp()
         self.series1_filename = self.create_tempfile(suffix='.qza').name
         self.series2_filename = self.create_tempfile(suffix='.qza').name
+        self.series3_filename = self.create_tempfile(suffix='.qza').name
 
         self.series_1 = pd.Series({
             'sample-foo-bar': 7.24, 'sample-baz-qux': 8.25,
@@ -538,6 +539,15 @@ class AlphaIntegrationTests(IntegrationTests):
             name='chao1'
         )
 
+        self.series_3 = pd.Series({
+            'sample-1': 9.01, 'sample-2': 9.04,
+            'sample-3': 9.31, 'sample-4': 9.33,
+            'sample-5': 9.09, 'sample-6': 9.02,
+            'sample-unique-name': 7.24,
+        },
+            name='shannon'
+        )
+
         imported_artifact = Artifact.import_data(
             "SampleData[AlphaDiversity]", self.series_1
         )
@@ -546,9 +556,14 @@ class AlphaIntegrationTests(IntegrationTests):
             "SampleData[AlphaDiversity]", self.series_2
         )
         imported_artifact.save(self.series2_filename)
+        imported_artifact = Artifact.import_data(
+            "SampleData[AlphaDiversity]", self.series_3
+        )
+        imported_artifact.save(self.series3_filename)
         config.resources.update({'alpha_resources': {
             'observed_otus': self.series1_filename,
             'chao1': self.series2_filename,
+            'shannon': self.series3_filename,
         }})
         resources.update(config.resources)
 
@@ -559,7 +574,8 @@ class AlphaIntegrationTests(IntegrationTests):
         self.assertEqual(response.status_code, 200)
         obs = json.loads(response.data)
         self.assertIn('alpha_metrics', obs)
-        self.assertCountEqual(['observed_otus', 'chao1'], obs['alpha_metrics'])
+        self.assertCountEqual(['observed_otus', 'chao1', 'shannon'],
+                              obs['alpha_metrics'])
 
     def test_group_summary(self):
         response = self.client.post(
@@ -855,3 +871,89 @@ class AllIntegrationTest(
         obs = json.loads(response.data)
         self.assertCountEqual([],
                               obs['sample_ids'])
+
+    def test_alpha_group_metadata_integration(self):
+        # TODO change this to alpha query
+        generic_metadata_query = {
+                    "condition": "AND",
+                    "rules": [
+                        {
+                            "id": "bmi_cat",
+                            "field": "bmi_cat",
+                            "type": "string",
+                            "input": "select",
+                            "operator": "equal",
+                            "value": "not",
+                        },
+                    ],
+                }
+
+        response = self.client.post(
+            '/results-api/diversity/alpha/group/shannon?return_raw=True',
+            content_type='application/json',
+            data=json.dumps({
+                "metadata_query": generic_metadata_query,
+            })
+        )
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(obs['alpha_diversity'].keys(),
+                              ['sample-2', 'sample-3', 'sample-5'])
+
+    def test_alpha_group_metadata_integration_with_sample_ids_OR(self):
+        generic_metadata_query = {
+            "condition": "AND",
+            "rules": [
+                {
+                    "id": "bmi_cat",
+                    "field": "bmi_cat",
+                    "type": "string",
+                    "input": "select",
+                    "operator": "equal",
+                    "value": "not",
+                },
+            ],
+        }
+
+        response = self.client.post(
+            '/results-api/diversity/alpha/group/shannon?return_raw=True',
+            content_type='application/json',
+            data=json.dumps({
+                "metadata_query": generic_metadata_query,
+                "sample_ids": ['sample-1'],
+                "condition": "OR",
+            })
+        )
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(obs['alpha_diversity'].keys(),
+                              ['sample-1', 'sample-2', 'sample-3', 'sample-5'])
+
+    def test_alpha_group_metadata_integration_with_sample_ids_AND(self):
+        generic_metadata_query = {
+            "condition": "AND",
+            "rules": [
+                {
+                    "id": "bmi_cat",
+                    "field": "bmi_cat",
+                    "type": "string",
+                    "input": "select",
+                    "operator": "equal",
+                    "value": "not",
+                },
+            ],
+        }
+
+        response = self.client.post(
+            '/results-api/diversity/alpha/group/shannon?return_raw=True',
+            content_type='application/json',
+            data=json.dumps({
+                "metadata_query": generic_metadata_query,
+                "sample_ids": ['sample-2', 'sample-3', 'sample-unique-name'],
+                "condition": "AND",
+            })
+        )
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(obs['alpha_diversity'].keys(),
+                              ['sample-2', 'sample-3'])

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -1039,3 +1039,28 @@ class AllIntegrationTest(
         obs = json.loads(response.data)
         self.assertCountEqual(obs['alpha_diversity'].keys(),
                               ['sample-2', 'sample-3'])
+
+    def test_alpha_group_metadata_integration_with_sample_ids_400(self):
+        generic_metadata_query = {
+            "condition": "AND",
+            "rules": [
+                {
+                    "id": "bmi_cat",
+                    "field": "bmi_cat",
+                    "type": "string",
+                    "input": "select",
+                    "operator": "equal",
+                    "value": "not",
+                },
+            ],
+        }
+
+        response = self.client.post(
+            '/results-api/diversity/alpha/group/shannon?return_raw=True',
+            content_type='application/json',
+            data=json.dumps({
+                "metadata_query": generic_metadata_query,
+                "sample_ids": ['sample-1'],
+            })
+        )
+        self.assertStatusCode(400, response)


### PR DESCRIPTION
This PR adds a mechanism for including samples that match metadata queries in alpha diversity group summaries.

A metadata query can be posted in addition to an array of sample ID's, or on its own.

If both are added, then a `condition` must be specified, which indicates whether the union or intersection of posted IDs and metadata-matched ID's should be returned.