### PR TITLE
List metadata available categories and available datasets

### DIFF
--- a/microsetta_public_api/api/datasets.py
+++ b/microsetta_public_api/api/datasets.py
@@ -1,0 +1,18 @@
+from microsetta_public_api.utils._utils import jsonify
+from microsetta_public_api.resources_alt import get_resources
+from microsetta_public_api.config import schema
+
+
+def available():
+    resources = get_resources()
+    escape = {schema.metadata_kw}
+    dataset_key = 'datasets'
+
+    if dataset_key not in resources:
+        return jsonify([]), 200
+
+    datasets = list(filter(
+        lambda x: x not in escape,
+        resources[dataset_key].keys()
+    ))
+    return jsonify(datasets), 200

--- a/microsetta_public_api/api/metadata.py
+++ b/microsetta_public_api/api/metadata.py
@@ -6,6 +6,11 @@ from microsetta_public_api.resources_alt import get_resources
 from microsetta_public_api.config import schema
 
 
+def categories():
+    repo = _get_repo()
+    return jsonify(repo.categories), 200
+
+
 def category_values(category):
     repo = _get_repo()
     if category in repo.categories:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -7,6 +7,23 @@ servers:
   - url: '/results-api'
 
 paths:
+  '/metadata/category/available':
+    get:
+      operationId: microsetta_public_api.api.metadata.categories
+      tags:
+        - Metadata
+      summary: Get categories of metadata available
+      description: Get categories of metadata available
+      responses:
+        '200':
+          description: Successfully returned categories
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
   '/metadata/category/values/{category}':
     get:
       operationId: microsetta_public_api.api.metadata.category_values

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -621,6 +621,21 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+  '/available/dataset':
+    get:
+      operationId: microsetta_public_api.api.datasets.available
+      summary: Get a list of available datasets
+      description: Get a list of available datasets
+      responses:
+        '200':
+          description: Successfully return available datasets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
   '/dataset/{dataset}/plotting/diversity/alpha/{alpha_metric}/percentiles-plot':
     parameters:
       - $ref: '#/components/parameters/namedDataset'

--- a/microsetta_public_api/api/tests/implementation_tests/test_datasets.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_datasets.py
@@ -1,0 +1,53 @@
+import json
+from unittest import mock
+from microsetta_public_api.utils.testing import MockedJsonifyTestCase
+from microsetta_public_api.api.datasets import available
+
+
+class DatasetsImplementationTests(MockedJsonifyTestCase):
+
+    jsonify_to_patch = [
+        'microsetta_public_api.api.datasets.jsonify',
+        'microsetta_public_api.utils._utils.jsonify',
+    ]
+
+    def test_datasets_available(self):
+        mock_resources = {
+            'metadata': 'some/stuff/here',
+            'datasets': {
+                'shotgun': {
+                    '__taxonomy__': ['foo'],
+                    '__alpha__': ['bar'],
+                },
+                '16S': {
+                    '__pcoa__': {
+                        'foo': 'bar',
+                    }
+                },
+                '__metadata__': '/path/to/md.txt',
+            }
+        }
+        with mock.patch('microsetta_public_api.api.datasets.get_resources') \
+                as mock_get_resources:
+            mock_get_resources.return_value = mock_resources
+            response, code = available()
+
+        self.assertEqual(code, 200)
+        obs = json.loads(response)
+        self.assertCountEqual(['shotgun', '16S'], obs)
+
+    def test_datasets_available_none(self):
+        mock_resources = {
+            'metadata': 'some/stuff/here',
+            'datasets': {
+                '__metadata__': '/path/to/md.txt',
+            }
+        }
+        with mock.patch('microsetta_public_api.api.datasets.get_resources') \
+                as mock_get_resources:
+            mock_get_resources.return_value = mock_resources
+            response, code = available()
+
+        self.assertEqual(code, 200)
+        obs = json.loads(response)
+        self.assertCountEqual([], obs)

--- a/microsetta_public_api/api/tests/implementation_tests/test_metadata.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_metadata.py
@@ -6,7 +6,9 @@ from microsetta_public_api.api.metadata import (
     category_values,
     filter_sample_ids,
     filter_sample_ids_query_builder,
+    categories,
 )
+import pandas as pd
 
 
 class MetadataImplementationTests(MockedJsonifyTestCase):
@@ -33,6 +35,19 @@ class MetadataImplementationTests(MockedJsonifyTestCase):
                 },
             ]
         }
+
+    def test_metadata_categories(self):
+        metadata_df = pd.DataFrame(
+            [[1, 2, 3], [4, 5, 6]], columns=['cat', 'fish', 'dog'],
+        )
+        with patch('microsetta_public_api.api.metadata._get_repo') as \
+                mock_repo:
+            mock_repo.return_value = MetadataRepo(metadata_df)
+            response, code = categories()
+        self.assertEqual(code, 200)
+        exp_values = ['cat', 'fish', 'dog']
+        obs = json.loads(response)
+        self.assertEqual(obs, exp_values)
 
     def test_metadata_category_values(self):
         with patch('microsetta_public_api.repo._metadata_repo.MetadataRepo.'

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -4,6 +4,35 @@ import json
 from microsetta_public_api.utils.testing import FlaskTests
 
 
+class MetadataCategoriesTests(FlaskTests):
+
+    def setUp(self):
+        super().setUp()
+        self.patcher = patch(
+            'microsetta_public_api.api.metadata.categories')
+        self.mock_method = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_metadata_categories(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify([
+                '20s',
+                '30s',
+                '40s',
+                '50',
+            ])
+        _, self.client = self.build_app_test_client()
+        exp = ['20s', '30s', '40s', '50']
+        response = self.client.get(
+            "/results-api/metadata/category/available")
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertListEqual(exp, obs)
+        self.mock_method.assert_called_with()
+
+
 class MetadataCategoryTests(FlaskTests):
 
     def setUp(self):

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -4,6 +4,34 @@ import json
 from microsetta_public_api.utils.testing import FlaskTests
 
 
+class DatasetsAvailableTests(FlaskTests):
+
+    def setUp(self):
+        super().setUp()
+        self.patcher = patch(
+            'microsetta_public_api.api.datasets.available')
+        self.mock_method = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_datasets_available(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify([
+                '16s',
+                'shotgun',
+            ])
+        _, self.client = self.build_app_test_client()
+        exp = ['16s', 'shotgun']
+        response = self.client.get(
+            "/results-api/available/dataset"
+        )
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertListEqual(exp, obs)
+        self.mock_method.assert_called_with()
+
+
 class MetadataCategoriesTests(FlaskTests):
 
     def setUp(self):

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -1938,6 +1938,14 @@ class AllIntegrationTest(
         PCoAIntegrationTests,
         ):
 
+    def test_available_datasets(self):
+        response = self.client.get('/results-api/available/dataset')
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertCountEqual(['16SAmplicon'],
+                              obs
+                              )
+
     def test_metadata_filter_on_taxonomy(self):
         response = self.client.get('/results-api/metadata/sample_ids?'
                                    'taxonomy=table2')

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -76,6 +76,15 @@ class MetadataIntegrationTests(IntegrationTests):
         }
         _update_resources_from_config(config_alt)
 
+    def test_metadata_available_categories(self):
+        exp = ['age_cat', 'bmi_cat', 'num_cat']
+        response = self.client.get(
+            'results-api/metadata/category/available'
+        )
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertListEqual(exp, obs)
+
     def test_metadata_category_values_returns_string_array(self):
         exp = ['30s', '40s', '50s']
         response = self.client.get(


### PR DESCRIPTION
Adds two new endpoints, `/metadata/category/available` and `/avaialable/dataset` that list the available metadata categories and available datasets, respectively.