### PR TITLE
NEW endpoint for querying metadata given sample ID's

### DIFF
--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -52,6 +52,34 @@ paths:
         '404':
             $ref: '#/components/responses/404NotFound'
 
+  '/metadata/values':
+    parameters:
+      - in: query
+        name: cat
+        description: Metadata categories to return
+        schema:
+          $ref: '#/components/schemas/metadataHeaders'
+    post:
+      operationId: microsetta_public_api.api.metadata.get_metadata_values
+      tags:
+        - Metadata
+      summary: Get metadata associated with given samples
+      description: Get metadata associated with given samples
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sampleIdArray'
+      responses:
+        '200':
+          description: Successfully returned metadata values
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/metadata"
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
   '/metadata/sample_ids':
     parameters:
       - in: query

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -61,6 +61,41 @@ class MetadataCategoriesTests(FlaskTests):
         self.mock_method.assert_called_with()
 
 
+class MetadataValuesTests(FlaskTests):
+
+    def setUp(self):
+        super().setUp()
+        self.patcher = patch(
+            'microsetta_public_api.api.metadata.get_metadata_values')
+        self.mock_method = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_metadata_values(self):
+        return_value = [
+            ['30s', 32, None],
+            ['20s', 45, 'str'],
+        ]
+        request_body = ['sample-1', 'sample-2']
+        with self.app_context():
+            self.mock_method.return_value = jsonify(return_value)
+
+        _, self.client = self.build_app_test_client()
+        exp = return_value
+        response = self.client.post(
+            "/results-api/metadata/values?cat=age_cat,age,name",
+            content_type='application/json',
+            data=json.dumps(request_body),
+        )
+        self.assertStatusCode(200, response)
+        obs = json.loads(response.data)
+        self.assertListEqual(exp, obs)
+        self.mock_method.assert_called_with(body=request_body,
+                                            cat=['age_cat', 'age', 'name']
+                                            )
+
+
 class MetadataCategoryTests(FlaskTests):
 
     def setUp(self):

--- a/microsetta_public_api/exceptions.py
+++ b/microsetta_public_api/exceptions.py
@@ -11,6 +11,10 @@ class UnknownResource(ValueError):
     pass
 
 
+class UnknownCategory(ValueError):
+    pass
+
+
 class IncompatibleOptions(ValueError):
     pass
 

--- a/microsetta_public_api/server.py
+++ b/microsetta_public_api/server.py
@@ -11,6 +11,7 @@ from microsetta_public_api.resources_alt import Q2Visitor
 from microsetta_public_api.exceptions import (UnknownMetric,
                                               UnknownResource,
                                               UnknownID,
+                                              UnknownCategory,
                                               IncompatibleOptions,
                                               )
 from flask import jsonify
@@ -54,6 +55,7 @@ def build_app():
     app.app.register_error_handler(UnknownMetric, handle_404)
     app.app.register_error_handler(UnknownResource, handle_404)
     app.app.register_error_handler(UnknownID, handle_404)
+    app.app.register_error_handler(UnknownCategory, handle_404)
     app.app.register_error_handler(IncompatibleOptions, handle_400)
 
     CORS(app.app)


### PR DESCRIPTION
Fixes #65 

This piece allows for metadata about specific sample ID's to be queried.