### PR TITLE
Add k nearest api

### DIFF
--- a/microsetta_public_api/api/diversity/beta.py
+++ b/microsetta_public_api/api/diversity/beta.py
@@ -4,3 +4,7 @@ def pcoa_contains_alt(named_sample_set, sample_id):
 
 def pcoa_contains(named_sample_set, sample_id):
     raise NotImplementedError()
+
+
+def k_nearest(dataset, beta_metric, k):
+    raise NotImplementedError()

--- a/microsetta_public_api/api/diversity/beta.py
+++ b/microsetta_public_api/api/diversity/beta.py
@@ -1,3 +1,25 @@
+from microsetta_public_api.utils import jsonify
+from microsetta_public_api.resources_alt import get_resources
+from microsetta_public_api.repo._beta_repo import BetaRepo
+from microsetta_public_api.exceptions import (
+    UnknownResource,
+)
+from microsetta_public_api.config import schema
+
+
+def _validate_dataset_beta(dataset, resource_getter):
+    try:
+        dataset_resource = resource_getter().gets('datasets', dataset)
+    except KeyError:
+        raise UnknownResource(f"Unknown dataset: '{dataset}'")
+    try:
+        beta_resource = dataset_resource.gets(schema.beta_kw)
+    except KeyError:
+        raise UnknownResource(f"No beta data (kw: '{schema.beta_kw}') for "
+                              f"dataset='{dataset}'.")
+    return beta_resource
+
+
 def pcoa_contains_alt(named_sample_set, sample_id):
     raise NotImplementedError()
 
@@ -6,5 +28,12 @@ def pcoa_contains(named_sample_set, sample_id):
     raise NotImplementedError()
 
 
-def k_nearest(dataset, beta_metric, k):
-    raise NotImplementedError()
+def k_nearest(dataset, beta_metric, k, sample_id):
+    beta_resource = _validate_dataset_beta(dataset,
+                                           resource_getter=get_resources)
+    beta_repo = BetaRepo(beta_resource)
+    k_nearest_ids = beta_repo.k_nearest(sample_id=sample_id,
+                                        metric=beta_metric,
+                                        k=k,
+                                        )
+    return jsonify(k_nearest_ids), 200

--- a/microsetta_public_api/api/diversity/beta.py
+++ b/microsetta_public_api/api/diversity/beta.py
@@ -31,7 +31,7 @@ def pcoa_contains(named_sample_set, sample_id):
 def k_nearest(dataset, beta_metric, k, sample_id):
     beta_resource = _validate_dataset_beta(dataset,
                                            resource_getter=get_resources)
-    beta_repo = BetaRepo(beta_resource)
+    beta_repo = BetaRepo(beta_resource.data)
     k_nearest_ids = beta_repo.k_nearest(sample_id=sample_id,
                                         metric=beta_metric,
                                         k=k,

--- a/microsetta_public_api/api/diversity/beta.py
+++ b/microsetta_public_api/api/diversity/beta.py
@@ -8,15 +8,17 @@ from microsetta_public_api.config import schema
 
 
 def _validate_dataset_beta(dataset, resource_getter):
-    try:
-        dataset_resource = resource_getter().gets('datasets', dataset)
-    except KeyError:
+    getter = resource_getter()
+    dataset_info = ('datasets', dataset)
+    if not getter.has(*dataset_info):
         raise UnknownResource(f"Unknown dataset: '{dataset}'")
-    try:
-        beta_resource = dataset_resource.gets(schema.beta_kw)
-    except KeyError:
-        raise UnknownResource(f"No beta data (kw: '{schema.beta_kw}') for "
+    dataset_resource = getter.gets(*dataset_info)
+
+    beta_kw = schema.beta_kw
+    if not dataset_resource.has(beta_kw):
+        raise UnknownResource(f"No beta data (kw: '{beta_kw}') for "
                               f"dataset='{dataset}'.")
+    beta_resource = dataset_resource.gets(beta_kw)
     return beta_resource
 
 

--- a/microsetta_public_api/api/diversity/tests/test_beta.py
+++ b/microsetta_public_api/api/diversity/tests/test_beta.py
@@ -51,6 +51,10 @@ class BetaTests(MockedJsonifyTestCase):
         self.mock_resources = self.res_patcher.start()
         self.mock_resources.return_value = self.resources
 
+    def tearDown(self):
+        self.res_patcher.stop()
+        super().tearDown()
+
     def test_k_nearest(self):
         results, code = k_nearest(
             dataset='dataset1',

--- a/microsetta_public_api/api/diversity/tests/test_beta.py
+++ b/microsetta_public_api/api/diversity/tests/test_beta.py
@@ -1,0 +1,105 @@
+import json
+from microsetta_public_api.api.diversity.beta import (
+    k_nearest,
+)
+
+from microsetta_public_api.config import DictElement, BetaElement
+
+from microsetta_public_api.exceptions import (
+    UnknownResource, UnknownID, UnknownMetric, InvalidParameter
+)
+from microsetta_public_api.utils.testing import (
+    MockedJsonifyTestCase,
+    TrivialVisitor,
+)
+from skbio import DistanceMatrix
+from unittest.mock import patch
+
+
+class BetaTests(MockedJsonifyTestCase):
+
+    jsonify_to_patch = [
+        'microsetta_public_api.api.diversity.beta.jsonify',
+        'microsetta_public_api.utils._utils.jsonify',
+    ]
+
+    def setUp(self):
+        super().setUp()
+        dm_values = [
+            [0, 1, 2, 3],
+            [1, 0, 3, 4],
+            [2, 3, 0, 5],
+            [3, 4, 5, 0]
+        ]
+        ids = ['s1', 's2', 's3', 's4']
+        dm = DistanceMatrix(
+            dm_values,
+            ids=ids,
+        )
+        self.resources = DictElement({
+            'datasets': DictElement({
+                'dataset1': DictElement({
+                    '__beta__': BetaElement({
+                        'unifrac': dm
+                    })
+                }),
+            }),
+        })
+        self.resources.accept(TrivialVisitor())
+        self.res_patcher = patch(
+            'microsetta_public_api.api.diversity.beta.get_resources')
+        self.mock_resources = self.res_patcher.start()
+        self.mock_resources.return_value = self.resources
+
+    def test_k_nearest(self):
+        results, code = k_nearest(
+            dataset='dataset1',
+            beta_metric='unifrac',
+            k=1,
+            sample_id='s1'
+        )
+        self.assertCountEqual(json.loads(results), ['s2'])
+
+        results, code = k_nearest(
+            dataset='dataset1',
+            beta_metric='unifrac',
+            k=2,
+            sample_id='s2'
+        )
+        self.assertCountEqual(json.loads(results), ['s1', 's3'])
+
+    def test_k_nearest_unknown_dataset(self):
+        with self.assertRaises(UnknownResource):
+            k_nearest(
+                dataset='dne',
+                beta_metric='unifrac',
+                k=2,
+                sample_id='s2'
+            )
+
+    def test_k_nearest_unknown_metric(self):
+        with self.assertRaises(UnknownMetric):
+            k_nearest(
+                dataset='dataset1',
+                beta_metric='unifork',
+                k=2,
+                sample_id='s2'
+            )
+
+    def test_k_nearest_unknown_id(self):
+        with self.assertRaises(UnknownID):
+            k_nearest(
+                dataset='dataset1',
+                beta_metric='unifrac',
+                k=2,
+                sample_id='s2-dne'
+            )
+
+    def test_k_nearest_invalid_k(self):
+        with self.assertRaises(InvalidParameter):
+            k_nearest(
+                dataset='dataset1',
+                beta_metric='unifrac',
+                k=724,
+                sample_id='s2'
+            )

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -1202,6 +1202,30 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+  '/dataset/{dataset}/diversity/beta/{beta_metric}/nearest':
+    parameters:
+      - $ref: '#/components/parameters/namedDataset'
+    get:
+      operationId: microsetta_public_api.api.diversity.beta.k_nearest
+      tags:
+        - Plotting
+        - Beta Diversity
+      summary: Get the k nearest sample ID's to a given sample ID
+      description: Get the k nearest sample ID's to a given sample ID
+      parameters:
+        - $ref: '#/components/parameters/betaMetric'
+        - $ref: '#/components/parameters/sampleIdQuery'
+        - $ref: '#/components/parameters/k'
+      responses:
+        '200':
+          description: Successfully return nearest sample IDs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sampleIdArray'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
 components:
   parameters:
     alphaMetric:
@@ -1224,6 +1248,13 @@ components:
       description: Value to populate NaN values with
       schema:
         type: string
+    k:
+      name: k
+      in: query
+      description: Number to select
+      schema:
+        type: integer
+        default: 1
     metadataCategories:
       name: metadata_categories
       in: query

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -1254,6 +1254,7 @@ components:
       description: Number to select
       schema:
         type: integer
+        minimum: 1
         default: 1
     metadataCategories:
       name: metadata_categories

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -1271,6 +1271,48 @@ class TaxonomyDataTableTests(FlaskTests):
         self.assertEqual(404, response.status_code)
 
 
+class BetaTests(FlaskTests):
+
+    def setUp(self):
+        super().setUp()
+        self.patcher = patch(
+            'microsetta_public_api.api.diversity.beta.k_nearest')
+        self.mock_method = self.patcher.start()
+        _, self.client = self.build_app_test_client()
+
+    def test_beta_k_nearest_default_k(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify(['a', 'b', 'c']), 200
+
+        response = self.client.get(
+            '/results-api/dataset/d1/diversity/beta/unifrac/nearest'
+            '?sample_id=s2'
+        )
+        self.mock_method.assert_called_with(
+            dataset='d1',
+            beta_metric='unifrac',
+            k=1,
+            sample_id='s2',
+        )
+        self.assertEqual(200, response.status_code)
+
+    def test_beta_k_nearest_k3(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify(['a', 'b', 'c']), 200
+
+        response = self.client.get(
+            '/results-api/dataset/d1/diversity/beta/unifrac/nearest'
+            '?sample_id=s2&k=3'
+        )
+        self.mock_method.assert_called_with(
+            dataset='d1',
+            beta_metric='unifrac',
+            k=3,
+            sample_id='s2',
+        )
+        self.assertEqual(200, response.status_code)
+
+
 class PlottingTests(FlaskTests):
 
     @classmethod

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -1280,6 +1280,10 @@ class BetaTests(FlaskTests):
         self.mock_method = self.patcher.start()
         _, self.client = self.build_app_test_client()
 
+    def tearDown(self):
+        self.patcher.stop()
+        super().tearDown()
+
     def test_beta_k_nearest_default_k(self):
         with self.app_context():
             self.mock_method.return_value = jsonify(['a', 'b', 'c']), 200

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 from flask import jsonify
 import json
 from microsetta_public_api.utils.testing import FlaskTests
+from microsetta_public_api.exceptions import UnknownID
 
 
 class DatasetsAvailableTests(FlaskTests):
@@ -1315,6 +1316,22 @@ class BetaTests(FlaskTests):
             sample_id='s2',
         )
         self.assertEqual(200, response.status_code)
+
+    def test_beta_k_nearest_unknown_id_api(self):
+        with self.app_context():
+            self.mock_method.side_effect = UnknownID()
+
+        response = self.client.get(
+            '/results-api/dataset/d1/diversity/beta/unifrac/nearest'
+            '?sample_id=s2&k=3'
+        )
+        self.mock_method.assert_called_with(
+            dataset='d1',
+            beta_metric='unifrac',
+            k=3,
+            sample_id='s2',
+        )
+        self.assertEqual(404, response.status_code)
 
 
 class PlottingTests(FlaskTests):

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -1360,10 +1360,10 @@ class BetaIntegreationTests(IntegrationTests):
     def setUp(self):
         super().setUp()
         dm_data = [
-            [0, 1, 2, 3,],
-            [1, 0, 3, 4,],
-            [2, 3, 0, 1,],
-            [3, 4, 1, 0,],
+            [0, 1, 2, 3, ],
+            [1, 0, 3, 4, ],
+            [2, 3, 0, 1, ],
+            [3, 4, 1, 0, ],
         ]
 
         ids = [f's{i}' for i in range(4)]

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -1380,7 +1380,7 @@ class BetaIntegreationTests(IntegrationTests):
             'datasets': {
                 '16SAmplicon': {
                     '__beta__': {
-                        'unifrac': self.beta_dm_path,
+                        'awesome-metric': self.beta_dm_path,
                     }
                 }
             }
@@ -1389,8 +1389,8 @@ class BetaIntegreationTests(IntegrationTests):
 
     def test_k_nearest(self):
         response = self.client.get(
-            '/results-api/dataset/16SAmplicon/diversity/beta/unifrac/nearest'
-            '?sample_id=s1'
+            '/results-api/dataset/16SAmplicon/diversity/beta/awesome-metric'
+            '/nearest?sample_id=s1'
         )
         self.assertStatusCode(200, response)
         exp = ['s0']
@@ -1399,8 +1399,8 @@ class BetaIntegreationTests(IntegrationTests):
 
     def test_k_nearest_k_2(self):
         response = self.client.get(
-            '/results-api/dataset/16SAmplicon/diversity/beta/unifrac/nearest'
-            '?sample_id=s1&k=2'
+            '/results-api/dataset/16SAmplicon/diversity/beta/awesome-metric'
+            '/nearest?sample_id=s1&k=2'
         )
         self.assertStatusCode(200, response)
         exp = ['s0', 's2']

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -1355,7 +1355,7 @@ class PlottingIntegrationTests(IntegrationTests):
         self.assertStatusCode(200, response)
 
 
-class BetaIntegreationTests(IntegrationTests):
+class BetaIntegrationTests(IntegrationTests):
 
     def setUp(self):
         super().setUp()
@@ -1381,8 +1381,8 @@ class BetaIntegreationTests(IntegrationTests):
                 '16SAmplicon': {
                     '__beta__': {
                         'awesome-metric': self.beta_dm_path,
-                    }
-                }
+                    },
+                },
             }
         }
         _update_resources_from_config(config_alt)

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -1407,6 +1407,13 @@ class BetaIntegrationTests(IntegrationTests):
         obs = json.loads(response.data)
         self.assertCountEqual(exp, obs)
 
+    def test_k_nearest_unknown_id(self):
+        response = self.client.get(
+            '/results-api/dataset/16SAmplicon/diversity/beta/awesome-metric'
+            '/nearest?sample_id=a'
+        )
+        self.assertStatusCode(404, response)
+
 
 class PlottingAltIntegrationTests(IntegrationTests):
 

--- a/microsetta_public_api/api/tests/test_integration.py
+++ b/microsetta_public_api/api/tests/test_integration.py
@@ -6,6 +6,7 @@ from biom.util import biom_open
 from qiime2 import Artifact, Metadata
 from numpy.testing import assert_allclose
 from skbio.stats.ordination import OrdinationResults
+from skbio import DistanceMatrix
 from copy import deepcopy
 
 from microsetta_public_api import config
@@ -1352,6 +1353,59 @@ class PlottingIntegrationTests(IntegrationTests):
             })
         )
         self.assertStatusCode(200, response)
+
+
+class BetaIntegreationTests(IntegrationTests):
+
+    def setUp(self):
+        super().setUp()
+        dm_data = [
+            [0, 1, 2, 3,],
+            [1, 0, 3, 4,],
+            [2, 3, 0, 1,],
+            [3, 4, 1, 0,],
+        ]
+
+        ids = [f's{i}' for i in range(4)]
+
+        self.dm = DistanceMatrix(dm_data, ids=ids)
+
+        imported_artifact = Artifact.import_data(
+            "DistanceMatrix", self.dm
+        )
+        self.beta_dm_path = self.create_tempfile(suffix='.qza').name
+        imported_artifact.save(self.beta_dm_path)
+
+        config_alt = {
+            'datasets': {
+                '16SAmplicon': {
+                    '__beta__': {
+                        'unifrac': self.beta_dm_path,
+                    }
+                }
+            }
+        }
+        _update_resources_from_config(config_alt)
+
+    def test_k_nearest(self):
+        response = self.client.get(
+            '/results-api/dataset/16SAmplicon/diversity/beta/unifrac/nearest'
+            '?sample_id=s1'
+        )
+        self.assertStatusCode(200, response)
+        exp = ['s0']
+        obs = json.loads(response.data)
+        self.assertCountEqual(exp, obs)
+
+    def test_k_nearest_k_2(self):
+        response = self.client.get(
+            '/results-api/dataset/16SAmplicon/diversity/beta/unifrac/nearest'
+            '?sample_id=s1&k=2'
+        )
+        self.assertStatusCode(200, response)
+        exp = ['s0', 's2']
+        obs = json.loads(response.data)
+        self.assertCountEqual(exp, obs)
 
 
 class PlottingAltIntegrationTests(IntegrationTests):

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -38,6 +38,7 @@ class TrivialVisitor(ConfigElementVisitor):
     visit_taxonomy = visit
     visit_pcoa = visit
     visit_metadata = visit
+    visit_beta = visit
 
 
 class TempfileTestCase(TestCase):


### PR DESCRIPTION
This support connects the `k` nearest functionality of `BetaRepo` to the Flask API.