### PR TITLE
Allow taxonomy features to be superset of abundance table

### DIFF
--- a/microsetta_public_api/exceptions.py
+++ b/microsetta_public_api/exceptions.py
@@ -28,6 +28,10 @@ class DisjointError(KeyError):
     pass
 
 
+class SubsetError(KeyError):
+    pass
+
+
 # Type errors
 class ConfigurationError(TypeError):
     pass

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -130,8 +130,7 @@ class Taxonomy(ModelBase):
                 set(self._table.ids(axis='observation')):
             raise DisjointError("Table and variances are disjoint")
 
-        if set(self._table.ids(axis='observation')) != \
-                set(self._features.index):
+        if not self._feature_id_lookup.issubset(set(self._features.index)):
             raise DisjointError("Table and features are disjoint")
 
         self._features = self._features.loc[self._feature_order]

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -8,7 +8,8 @@ import numpy as np
 import pandas as pd
 import scipy.sparse as ss
 
-from microsetta_public_api.exceptions import DisjointError, UnknownID
+from microsetta_public_api.exceptions import (DisjointError, UnknownID,
+                                              SubsetError)
 from microsetta_public_api.utils import DataTable
 from ._base import ModelBase
 
@@ -131,7 +132,8 @@ class Taxonomy(ModelBase):
             raise DisjointError("Table and variances are disjoint")
 
         if not self._feature_id_lookup.issubset(set(self._features.index)):
-            raise DisjointError("Table and features are disjoint")
+            raise SubsetError("Table features are not a subset of the "
+                              "taxonomy information")
 
         self._features = self._features.loc[self._feature_order]
         self._variances = self._variances.sort_order(self._feature_order,

--- a/microsetta_public_api/models/tests/test_taxonomy.py
+++ b/microsetta_public_api/models/tests/test_taxonomy.py
@@ -37,6 +37,11 @@ class TaxonomyTests(unittest.TestCase):
                                          columns=['Feature ID', 'Taxon',
                                                   'Confidence'])
         self.taxonomy2_df.set_index('Feature ID', inplace=True)
+
+        self.taxonomy_superset_df = self.taxonomy2_df.copy()
+        self.taxonomy_superset_df.loc['feature-2'] = \
+            self.taxonomy_df.loc['feature-2']
+
         self.taxonomy_greengenes_df = pd.DataFrame(
             [['feature-1', 'k__a; p__b; o__c', 0.123],
              ['feature-2', 'k__a; p__b; o__c;f__d;g__e', 0.34],
@@ -100,6 +105,9 @@ class TaxonomyTests(unittest.TestCase):
         with self.assertRaisesRegex(DisjointError,
                                     "Table and features are disjoint"):
             Taxonomy(self.table2, self.taxonomy_df)
+
+    def test_init_allow_taxonomy_superset(self):
+        Taxonomy(self.table, self.taxonomy_superset_df)
 
     def test_init_disjoint_variances(self):
         bad = self.table_vars.copy()

--- a/microsetta_public_api/models/tests/test_taxonomy.py
+++ b/microsetta_public_api/models/tests/test_taxonomy.py
@@ -7,7 +7,8 @@ import numpy.testing as npt
 
 from qiime2 import Artifact
 from microsetta_public_api.models._taxonomy import GroupTaxonomy, Taxonomy
-from microsetta_public_api.exceptions import DisjointError, UnknownID
+from microsetta_public_api.exceptions import (DisjointError, UnknownID,
+                                              SubsetError)
 from microsetta_public_api.utils import DataTable, create_data_entry
 
 
@@ -99,11 +100,11 @@ class TaxonomyTests(unittest.TestCase):
                          list(taxonomy._variances.ids(axis='observation')))
 
     def test_init_disjoint(self):
-        with self.assertRaisesRegex(DisjointError,
-                                    "Table and features are disjoint"):
+        with self.assertRaisesRegex(SubsetError,
+                                    "not a subset"):
             Taxonomy(self.table, self.taxonomy2_df)
-        with self.assertRaisesRegex(DisjointError,
-                                    "Table and features are disjoint"):
+        with self.assertRaisesRegex(SubsetError,
+                                    "not a subset"):
             Taxonomy(self.table2, self.taxonomy_df)
 
     def test_init_allow_taxonomy_superset(self):


### PR DESCRIPTION
Processing for WGS data right is not explicitly filtering the taxonomy data to only the features present. This is preferred as it would be a specific need for WGS in the shotgun processing rather than general. For 16S  processing, we only obtain taxonomy for the features present whereas for shotgun we just use the existing Woltka taxonomy mapping file. 