### PR TITLE
Initial rank support

### DIFF
--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -1120,7 +1120,7 @@ paths:
         - $ref: '#/components/parameters/taxonomyResource'
       responses:
         '200':
-          description: Successfuly return taxonomy information
+          description: Successfully return taxonomy information
           content:
             application/json:
               schema:
@@ -1128,6 +1128,62 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+  '/dataset/{dataset}/taxonomy/ranks/{resource}':
+    parameters:
+      - $ref: '#/components/parameters/namedDataset'
+      - $ref: '#/components/parameters/taxonomyResource'
+      - $ref: '#/components/parameters/ranksSampleSize'
+    get:
+      operationId: microsetta_public_api.api.taxonomy.ranks_sample
+      tags:
+        - Taxonomy
+      summary: Obtain a random sample of the rank order of observed taxa
+      description: |
+        Obtain a random sample of the rank order of observed taxa in the dataset.
+        A high value for a rank means that taxon was observed to have a high relative
+        abundance in a particular sample. A low value means that taxon was observed
+        to have a low relative abundance. The data being sampled are a reduced set 
+        of the overall taxa in the dataset, such that low prevalence taxa are 
+        removed prior to ranking. In addition, ranks are only computed over the 
+        genus level.
+      responses:
+        '200':
+          description: Successfully obtained a sampling of ranks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/taxonomyRanks'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
+  '/dataset/{dataset}/taxonomy/ranks/{resource}/sample/{sample_id}':
+    parameters:
+      - $ref: '#/components/parameters/namedDataset'
+      - $ref: '#/components/parameters/taxonomyResource'
+      - $ref: '#/components/parameters/sampleIdPath'
+    get:
+      operationId: microsetta_public_api.api.taxonomy.ranks_specific
+      tags:
+        - Taxonomy
+      summary: Obtain the rank order of observed taxa in a specific sample
+      description: |
+        Obtain the rank order of observed taxa in a specific sample. A high
+        value for a rank means that taxon was observed to have a high relative
+        abundance in a particular sample. A low value means that taxon was
+        observed to have a low relative abundance. The ranks are a
+        reduced set of the overall taxa in the dataset, such that low
+        prevalence taxa are removed prior to ranking. In addition, ranks are
+        only computed over the genus level.
+      responses:
+        '200':
+          description: Successfully obtained ranks for a specific sample
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/taxonomyRanks'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+  
   '/dataset/{dataset}/taxonomy/present/group/{resource}':
     parameters:
       - $ref: '#/components/parameters/namedDataset'
@@ -1313,6 +1369,14 @@ components:
       schema:
         $ref: '#/components/schemas/percentiles'
       required: false
+    ranksSampleSize:
+      name: sample_size
+      in: query
+      description: The size of the random sample of ranks to obtain
+      schema:
+        type: integer
+        example: 30000
+      required: true
 
   schemas:
     alphaMetric:
@@ -1548,6 +1612,7 @@ components:
                   - "Kingdom"
                   - "Genus"
                   - "relativeAbundance"
+
     taxonomyFeatures:
       type: object
       required:
@@ -1579,6 +1644,40 @@ components:
           example:
             - 0.05
             - 0.11
+
+    taxonomyRanks:
+      type: object
+      required:
+        - taxa
+        - ranks
+        - taxa-order
+      properties:
+        genera:
+          type: array
+          items:
+            type: string
+          example:
+            - "Bacteroides"
+            - "Prevotella"
+            - "Prevotella"
+            - "Ruminococcus"
+        ranks:
+          type: array
+          items:
+            type: number
+          example:
+            - 15
+            - 12
+            - 12
+            - 11
+        genera-order:
+          type: array
+          items:
+            type: string
+          example:
+            - "Bacteroides"
+            - "Prevotella"
+            - "Ruminococcus"
 
   responses:
     200VegaSchema:

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -1648,11 +1648,11 @@ components:
     taxonomyRanks:
       type: object
       required:
-        - taxa
-        - ranks
-        - taxa-order
+        - Taxon
+        - Rank
+        - Taxa-order
       properties:
-        genera:
+        Taxon:
           type: array
           items:
             type: string
@@ -1661,7 +1661,7 @@ components:
             - "Prevotella"
             - "Prevotella"
             - "Ruminococcus"
-        ranks:
+        Rank:
           type: array
           items:
             type: number
@@ -1670,7 +1670,7 @@ components:
             - 12
             - 12
             - 11
-        genera-order:
+        Taxa-order:
           type: array
           items:
             type: string

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -71,7 +71,6 @@ def _summarize_group(sample_ids, table_name, taxonomy_repo):
 
     taxonomy_data = taxonomy_.get_group(sample_ids, '').to_dict()
     del taxonomy_data['name']
-    del taxonomy_data['feature_ranks']
     response = jsonify(taxonomy_data)
     return response, 200
 

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -164,8 +164,23 @@ def _exists(resource, samples, taxonomy_repo):
 
 
 def ranks_sample(dataset, resource, sample_size):
-    pass
+    taxonomy_repo = _get_taxonomy_repo(dataset)
+    taxonomy_ = taxonomy_repo.model(resource)
+    summary = taxonomy_.ranks_sample(sample_size)
+    response = jsonify(summary.to_dict())
+    return response, 200
 
 
 def ranks_specific(dataset, resource, sample_id):
-    pass
+    taxonomy_repo = _get_taxonomy_repo(dataset)
+
+    error_response = _check_resource_and_missing_ids(taxonomy_repo,
+                                                     sample_id,
+                                                     resource)
+    if error_response:
+        return error_response
+
+    taxonomy_ = taxonomy_repo.model(resource)
+    summary = taxonomy_.ranks_specific(sample_id)
+    response = jsonify(summary.to_dict())
+    return response, 200

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -161,3 +161,11 @@ def _exists(resource, samples, taxonomy_repo):
         return missing_resource
 
     return jsonify(taxonomy_repo.exists(samples, resource)), 200
+
+
+def ranks_sample(dataset, resource, sample_size):
+    pass
+
+
+def ranks_specific(dataset, resource, sample_id):
+    pass

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -167,8 +167,13 @@ def ranks_sample(dataset, resource, sample_size):
     taxonomy_repo = _get_taxonomy_repo(dataset)
     taxonomy_ = taxonomy_repo.model(resource)
     summary = taxonomy_.ranks_sample(sample_size)
-    response = jsonify(summary.to_dict())
-    return response, 200
+    order = taxonomy_.ranks_order(summary['Taxon'])
+
+    payload = summary.to_dict('list')
+    payload.pop('Sample ID')
+    payload['Taxa-order'] = order
+
+    return jsonify(payload), 200
 
 
 def ranks_specific(dataset, resource, sample_id):
@@ -182,5 +187,10 @@ def ranks_specific(dataset, resource, sample_id):
 
     taxonomy_ = taxonomy_repo.model(resource)
     summary = taxonomy_.ranks_specific(sample_id)
-    response = jsonify(summary.to_dict())
-    return response, 200
+    order = taxonomy_.ranks_order(summary['Taxon'])
+
+    payload = summary.to_dict('list')
+    payload.pop('Sample ID')
+    payload['Taxa-order'] = order
+
+    return jsonify(payload), 200

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -165,6 +165,13 @@ def _exists(resource, samples, taxonomy_repo):
 
 def ranks_sample(dataset, resource, sample_size):
     taxonomy_repo = _get_taxonomy_repo(dataset)
+
+    error_response = _check_resource_and_missing_ids(taxonomy_repo,
+                                                     [],
+                                                     resource)
+    if error_response:
+        return error_response
+
     taxonomy_ = taxonomy_repo.model(resource)
     summary = taxonomy_.ranks_sample(sample_size)
     order = taxonomy_.ranks_order(summary['Taxon'])
@@ -180,7 +187,7 @@ def ranks_specific(dataset, resource, sample_id):
     taxonomy_repo = _get_taxonomy_repo(dataset)
 
     error_response = _check_resource_and_missing_ids(taxonomy_repo,
-                                                     sample_id,
+                                                     [sample_id, ],
                                                      resource)
     if error_response:
         return error_response

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -1272,6 +1272,64 @@ class TaxonomyDataTableTests(FlaskTests):
         self.assertEqual(404, response.status_code)
 
 
+class TaxonomyRanksSampleAPITests(FlaskTests):
+    def setUp(self):
+        super().setUp()
+        self.patcher = patch(
+            'microsetta_public_api.api.taxonomy.ranks_sample')
+        self.mock_method = self.patcher.start()
+        _, self.client = self.build_app_test_client()
+
+    def tearDown(self):
+        self.patcher.stop()
+        super().tearDown()
+
+    def test_ranks_sample_valid(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify(
+                {
+                    'Taxon': ['foo', 'bar'],
+                    'Taxa-order': ['bar', 'foo'],
+                    'Rank': [1, 2]
+                }
+            ), 200
+
+        response = self.client.get('/results-api/dataset/d1/taxonomy/'
+                                   'ranks/greengenes?sample_size=2')
+        self.mock_method.assert_called_with(
+            dataset='d1', resource='greengenes', sample_size=2)
+        self.assertEqual(200, response.status_code)
+
+
+class TaxonomyRanksSpecificAPITests(FlaskTests):
+    def setUp(self):
+        super().setUp()
+        self.patcher = patch(
+            'microsetta_public_api.api.taxonomy.ranks_specific')
+        self.mock_method = self.patcher.start()
+        _, self.client = self.build_app_test_client()
+
+    def tearDown(self):
+        self.patcher.stop()
+        super().tearDown()
+
+    def test_ranks_specific_valid(self):
+        with self.app_context():
+            self.mock_method.return_value = jsonify(
+                {
+                    'Taxon': ['foo', 'bar'],
+                    'Taxa-order': ['bar', 'foo'],
+                    'Rank': [1, 2]
+                }
+            ), 200
+
+        response = self.client.get('/results-api/dataset/d1/taxonomy/'
+                                   'ranks/greengenes/sample/foo')
+        self.mock_method.assert_called_with(
+            dataset='d1', resource='greengenes', sample_id='foo')
+        self.assertEqual(200, response.status_code)
+
+
 class BetaTests(FlaskTests):
 
     def setUp(self):

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -98,7 +98,8 @@ class Taxonomy(ModelBase):
         variances : biom.Table, optional
             Variation information about a taxon within a label.
         rank_level : int
-            The taxonomic level to compute ranked data over
+            The taxonomic level (depth) to compute ranks over. Level 0 is
+            domain, level 1 is phylum, etc.
         """
         self._table = table.norm(inplace=False)
         self._group_id_lookup = set(self._table.ids())
@@ -269,8 +270,8 @@ class Taxonomy(ModelBase):
 
             unk = taxa - known
             if len(unk) > 0:
-                raise UnknownID("One or more unknown names: %s" %
-                                ",".join(unk))
+                raise UnknownID("One or more names are not in the top "
+                                "ranks: %s" % ",".join(unk))
 
         return [t for t in self._ranked_order.index if t in taxa]
 

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -14,8 +14,8 @@ from microsetta_public_api.utils import DataTable
 from ._base import ModelBase
 
 _gt_named = namedtuple('GroupTaxonomy', ['name', 'taxonomy', 'features',
-                                         'feature_values', 'feature_variances',
-                                         'feature_ranks'])
+                                         'feature_values',
+                                         'feature_variances'])
 
 
 class GroupTaxonomy(_gt_named):
@@ -38,11 +38,6 @@ class GroupTaxonomy(_gt_named):
         etc)
     feature_variances : list of float
         Values associated with the variance of the features
-    feature_ranks : list of float
-        Values associated with the rank of the features. For example, if
-        an instance represents multiple samples (e.g., all fecal samples), then
-        feature_ranks would describe the median rank for a corresponding
-        feature.
 
     Notes
     -----
@@ -53,9 +48,7 @@ class GroupTaxonomy(_gt_named):
     __slots__ = ()
 
     def __init__(self, *args, name=None, taxonomy=None, features=None,
-                 feature_values=None, feature_variances=None,
-                 feature_ranks=None,
-                 ):
+                 feature_values=None, feature_variances=None):
         if args:
             raise NotImplementedError("%s only supports kwargs" %
                                       str(self.__class__))
@@ -74,10 +67,6 @@ class GroupTaxonomy(_gt_named):
         if feature_variances is not None and len(features) != len(
                 feature_variances):
             raise ValueError("features and feature_variances have a length "
-                             "mismatch")
-
-        if feature_ranks is not None and len(features) != len(feature_ranks):
-            raise ValueError("features and feature_ranks have a length "
                              "mismatch")
 
         super().__init__()
@@ -152,7 +141,7 @@ class Taxonomy(ModelBase):
                                       for i, lineage in
                                       feature_taxons['Taxon'].items()}
 
-    def _rankdata(self, rank_level):
+    def _rankdata(self, rank_level) -> (pd.DataFrame, pd.Series):
         index = {idx: v.split(';')[rank_level].strip()
                  for idx, v in self._features['Taxon'].items()}
 
@@ -195,7 +184,7 @@ class Taxonomy(ModelBase):
 
         return base_df_melted, median_order
 
-    def _rankdata_order(self, table, top_n=50):
+    def _rankdata_order(self, table, top_n=50) -> pd.Series:
         # rank by median
         medians = []
         for v in table.iter_data(axis='observation', dense=False):
@@ -277,7 +266,6 @@ class Taxonomy(ModelBase):
                              features=list(features),
                              feature_values=list(feature_values),
                              feature_variances=list(feature_variances),
-                             feature_ranks=None,
                              )
 
     def presence_data_table(self, ids: Iterable[str]) -> DataTable:

--- a/microsetta_public_api/models/tests/test_taxonomy.py
+++ b/microsetta_public_api/models/tests/test_taxonomy.py
@@ -147,8 +147,7 @@ class TaxonomyTests(unittest.TestCase):
                             taxonomy='((((feature-1,((feature-2)e)d)c)b)a);',
                             features=['feature-1', 'feature-2'],
                             feature_values=[1. / 5, 4. / 5],
-                            feature_variances=[0.0, 0.0],
-                            feature_ranks=None)
+                            feature_variances=[0.0, 0.0])
         obs = taxonomy.get_group(['sample-2'])
         self.assertEqual(obs, exp)
 
@@ -158,8 +157,7 @@ class TaxonomyTests(unittest.TestCase):
                             taxonomy='((((feature-1,((feature-2)e)d)c)b,(((feature-3)h)g)f)a);',  # noqa
                             features=['feature-1', 'feature-2', 'feature-3'],
                             feature_values=[1. / 10, 6. / 10, 3. / 10],
-                            feature_variances=[0.0, 0.0, 0.0],
-                            feature_ranks=None)
+                            feature_variances=[0.0, 0.0, 0.0])
         obs = taxonomy.get_group(['sample-1', 'sample-2'], 'foo')
         self.assertEqual(obs.name, exp.name)
         self.assertEqual(obs.taxonomy, exp.taxonomy)
@@ -173,8 +171,7 @@ class TaxonomyTests(unittest.TestCase):
                             taxonomy='((((((feature-2)e)d)c)b,(((feature-3)h)g)f)a);',  # noqa
                             features=['feature-2', 'feature-3'],
                             feature_values=[2. / 5, 3. / 5],
-                            feature_variances=[2.0, 3.0],
-                            feature_ranks=None,)
+                            feature_variances=[2.0, 3.0])
         obs = taxonomy.get_group(['sample-1'])
         self.assertEqual(obs, exp)
 
@@ -262,8 +259,7 @@ class GroupTaxonomyTests(unittest.TestCase):
                                  taxonomy=self.tstr,
                                  features=['feature-1', 'feature-2'],
                                  feature_values=[1. / 5, 4. / 5],
-                                 feature_variances=[0.0, 0.0],
-                                 feature_ranks=[1.0, 2.0])
+                                 feature_variances=[0.0, 0.0])
 
     def test_init(self):
         self.assertEqual(self.obj.name, 'sample-2')
@@ -271,7 +267,6 @@ class GroupTaxonomyTests(unittest.TestCase):
         self.assertEqual(self.obj.features, ['feature-1', 'feature-2'])
         self.assertEqual(self.obj.feature_values, [1. / 5, 4. / 5])
         self.assertEqual(self.obj.feature_variances, [0.0, 0.0])
-        self.assertEqual(self.obj.feature_ranks, [1.0, 2.0])
 
     def test_init_tree_missing_feature(self):
         with self.assertRaisesRegex(UnknownID,
@@ -280,8 +275,7 @@ class GroupTaxonomyTests(unittest.TestCase):
                           taxonomy=self.tstr,
                           features=['feature-1', 'feature-3'],
                           feature_values=[1. / 5, 4. / 5],
-                          feature_variances=[0.0, 0.0],
-                          feature_ranks=[1.0, 2.0])
+                          feature_variances=[0.0, 0.0])
 
     def test_init_feature_value_lengths(self):
         with self.assertRaisesRegex(ValueError,
@@ -290,8 +284,7 @@ class GroupTaxonomyTests(unittest.TestCase):
                           taxonomy=self.tstr + 'feature-3',
                           features=['feature-1', 'feature-2', 'feature-3'],
                           feature_values=[1. / 5, 4. / 5],
-                          feature_variances=[0.0, 0.0],
-                          feature_ranks=[1.0, 2.0])
+                          feature_variances=[0.0, 0.0])
 
         with self.assertRaisesRegex(ValueError,
                                     "length mismatch"):
@@ -299,16 +292,14 @@ class GroupTaxonomyTests(unittest.TestCase):
                           taxonomy=self.tstr,
                           features=['feature-1', 'feature-2'],
                           feature_values=[1. / 5, ],
-                          feature_variances=[0.0, 0.0],
-                          feature_ranks=[1.0, 2.0])
+                          feature_variances=[0.0, 0.0])
 
     def test_to_dict(self):
         exp = {'name': 'sample-2',
                'taxonomy': self.tstr,
                'features': ['feature-1', 'feature-2'],
                'feature_values': [1. / 5, 4. / 5],
-               'feature_variances': [0.0, 0.0],
-               'feature_ranks': [1.0, 2.0]}
+               'feature_variances': [0.0, 0.0]}
         obs = self.obj.to_dict()
         self.assertEqual(obs, exp)
 

--- a/microsetta_public_api/models/tests/test_taxonomy.py
+++ b/microsetta_public_api/models/tests/test_taxonomy.py
@@ -118,6 +118,29 @@ class TaxonomyTests(unittest.TestCase):
                                     "Table and variances are disjoint"):
             Taxonomy(self.table, self.taxonomy_df, bad)
 
+    def test_init_rankdata(self):
+        exp = pd.DataFrame([['c', 'sample-1', 1.],
+                            ['c', 'sample-2', 1],
+                            ['c', 'sample-3', 2],
+                            ['g', 'sample-1', 2],
+                            ['g', 'sample-3', 1]],
+                           columns=['Taxon', 'Sample ID', 'Rank'])
+
+        taxonomy = Taxonomy(self.table, self.taxonomy_df, rank_level=2)
+
+        obs = taxonomy._ranked
+        obs.sort_values(['Taxon', 'Sample ID'], inplace=True)
+        exp.sort_values(['Taxon', 'Sample ID'], inplace=True)
+        obs.reset_index(drop=True, inplace=True)
+        exp.reset_index(drop=True, inplace=True)
+        pdt.assert_frame_equal(obs, exp, check_like=True)
+
+    def test_init_rankdata_order(self):
+        exp = ['g', 'c']
+        taxonomy = Taxonomy(self.table, self.taxonomy_df, rank_level=2)
+        obs = list(taxonomy._ranked_order.index)
+        self.assertEqual(obs, exp)
+
     def test_get_group(self):
         taxonomy = Taxonomy(self.table, self.taxonomy_df)
         exp = GroupTaxonomy(name='sample-2',

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -111,7 +111,9 @@ def _transform_single_table(dict_, resource_name):
         table = new_resource['table']
         taxonomy = new_resource['feature-data-taxonomy']
         variances = new_resource.get('variances', None)
-        model = TaxonomyModel(table, taxonomy, variances)
+
+        # rank_level=5 -> genus
+        model = TaxonomyModel(table, taxonomy, variances, rank_level=5)
         new_resource['model'] = model
 
     return new_resource


### PR DESCRIPTION
Addresses #72.

A few notes:

- for caching, it is advantageous to limit to the top few taxa upfront to keep the overall data small (and plotting is oriented around the top few not everything)
- there was a `feature_ranks` attribute, but I don't think it was actually being used, and I'll remove it in coming commits
- not attached to endpoints yet
- I think we want to just limit this to a particular taxonomic rank right now, and can expand in the future if we need