### PR TITLE
BUG: filtering ranks rather differently from the proof of concept

### DIFF
--- a/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
@@ -804,7 +804,7 @@ class TestTaxonomyAltImplementation(MockedJsonifyTestCase):
         api_out = json.loads(response.data)
         exp = {'Taxon': ['b', 'f'],
                'Rank': [1.0, 2.0],
-               'Taxa-order': ['f', 'b']}
+               'Taxa-order': ['b', 'f']}
         self.assertEqual(api_out, exp)
 
     def test_taxonomy_ranks_specific_unknown_dataset(self):

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -161,19 +161,13 @@ class Taxonomy(ModelBase):
         # 16S mitochondria reads report as g__human
         keep = {v for v in base.ids(axis='observation')
                 if 'human' not in v.lower()}
-        keep -= {None, "", 'Non-specific'}
+        keep -= {None, "", 'Non-specific', 'g__'}
         base.filter(keep, axis='observation')
 
-        # remove taxa not present in at least 10% of samples
-        min_ = len(base.ids()) * 0.1
-
-        base.filter(lambda v, i, m: (v > 0).sum() > min_, axis='observation')
-        base.rankdata(inplace=True)
-
-        median_order = self._rankdata_order(base)
-
         # reduce to the top observed taxa
+        median_order = self._rankdata_order(base)
         base.filter(set(median_order.index), axis='observation')
+        base.rankdata(inplace=True)
 
         # convert to a melted dataframe
         base_df = base.to_dataframe(dense=True)

--- a/microsetta_public_api/models/tests/test_taxonomy.py
+++ b/microsetta_public_api/models/tests/test_taxonomy.py
@@ -138,7 +138,7 @@ class TaxonomyTests(unittest.TestCase):
         pdt.assert_frame_equal(obs, exp, check_like=True)
 
     def test_init_rankdata_order(self):
-        exp = ['g', 'c']
+        exp = ['c', 'g']
         taxonomy = Taxonomy(self.table, self.taxonomy_df, rank_level=2)
         obs = list(taxonomy._ranked_order.index)
         self.assertEqual(obs, exp)
@@ -200,12 +200,12 @@ class TaxonomyTests(unittest.TestCase):
     def test_ranks_order(self):
         taxonomy = Taxonomy(self.table, self.taxonomy_df, rank_level=2)
 
-        exp = ['g', 'c']
+        exp = ['c', 'g']
         obs = taxonomy.ranks_order()
         self.assertEqual(obs, exp)
 
-        exp = ['g', 'c']
-        obs = taxonomy.ranks_order(['c', 'g'])
+        exp = ['c', 'g']
+        obs = taxonomy.ranks_order(['g', 'c'])
         self.assertEqual(obs, exp)
 
         exp = ['c']


### PR DESCRIPTION
Removed the 10% filter as it was misguided, and upstream of reducing to the top N taxa

Now ranking after limiting to the top taxa

Removed "g__" as it's meaningless 