### PR TITLE
NEW Add empress for taxonomy

### DIFF
--- a/ci/conda_requirements.yml
+++ b/ci/conda_requirements.yml
@@ -13,6 +13,7 @@ dependencies:
   - numpy
   - pyyaml
   - qiime2
+  - q2templates
   - q2-types
   - altair
   - jsonschema

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -2,3 +2,4 @@ connexion[swagger-ui]
 pytest
 pytest-cov
 flake8
+empress>=1.0.1

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-cov
 flake8
 empress>=1.0.1
+iow

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -1114,6 +1114,27 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+  '/dataset/{dataset}/taxonomy/empress/{resource}':
+    parameters:
+      - $ref: '#/components/parameters/namedDataset'
+      - $ref: '#/components/parameters/taxonomyResource'
+    get:
+      operationId: microsetta_public_api.api.taxonomy.get_empress
+      tags:
+        - Taxonomy
+        - Plotting
+      summary: Get the empress object corresponding to the taxonomy for a given dataset.
+      description: Get the empress object corresponding to the taxonomy for a given dataset.
+      responses:
+        '200':
+          description: An empress object.
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
   '/dataset/{dataset}/taxonomy/group/{resource}':
     parameters:
       - $ref: '#/components/parameters/namedDataset'

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -1132,6 +1132,9 @@ paths:
             application/json:
               schema:
                 type: object
+                description: |
+                  An empress object that can be used to initailize an empress plot.
+                  Find more info [here](https://github.com/biocore/empress/blob/v1.0.1/empress/core.py).
         '404':
           $ref: '#/components/responses/404NotFound'
 
@@ -1569,9 +1572,7 @@ components:
       $ref: '#/components/schemas/anyValue'
     namedDataset:
       type: string
-      example:
-        - '16SAmplicon'
-        - 'ShotgunMetagenomics'
+      example: '16S'
     namedSampleSet:
       type: string
       example: 'body-site'

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -7,6 +7,7 @@ from microsetta_public_api.utils._utils import (
     check_missing_ids,
     stepwise_resource_getter,
 )
+from empress import Empress
 
 
 def _get_taxonomy_repo(dataset):
@@ -42,6 +43,13 @@ def summarize_group(body, resource):
     sample_ids = body['sample_ids']
     taxonomy_repo = TaxonomyRepo()
     return _summarize_group(sample_ids, resource, taxonomy_repo)
+
+
+def get_empress(dataset, resource):
+    taxonomy_repo = _get_taxonomy_repo(dataset)
+    taxonomy_model = taxonomy_repo.model(resource)
+    empress_model = Empress(taxonomy_model.bp_tree)
+    return empress_model._to_dict()
 
 
 def _check_resource_and_missing_ids(taxonomy_repo, sample_ids, resource):

--- a/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
+++ b/microsetta_public_api/api/tests/implementation_tests/test_taxonomy.py
@@ -25,7 +25,8 @@ from microsetta_public_api.api.taxonomy import (
     exists_single_alt,
     exists_group_alt,
     ranks_sample,
-    ranks_specific
+    ranks_specific,
+    get_empress,
 )
 from microsetta_public_api.config import DictElement, TaxonomyElement
 
@@ -705,6 +706,16 @@ class TestTaxonomyAltImplementation(MockedJsonifyTestCase):
             'microsetta_public_api.api.taxonomy.get_resources')
         cls.mock_resources = cls.res_patcher.start()
         cls.mock_resources.return_value = cls.resources
+
+    def test_get_empress(self):
+        response = get_empress('dataset1', self.table_name)
+        tree_names = [
+            -1, 'feature-1', 'feature-2', 'e', 'd', 'c', 'b', 'feature-3', 'h',
+            'g', 'f', 'a', None
+        ]
+        self.assertListEqual(
+            tree_names, response['names']
+        )
 
     def test_single_sample_alt(self):
         response, code = single_sample_alt('dataset1', 'sample-1',

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -1146,6 +1146,22 @@ class TaxonomyResourcesAPITests(FlaskTests):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_taxonomy_empress(self):
+        with patch('microsetta_public_api.api.taxonomy'
+                   '.get_empress'
+                   ) as mock_method, self.app_context():
+            mock_method.return_value = {'tree': [7], 'other_stuff': None}
+            _, self.client = self.build_app_test_client()
+            response = self.client.get(
+                '/results-api/dataset/datasetName/taxonomy/empress/groupName'
+            )
+            mock_method.assert_called_with(dataset='datasetName',
+                                           resource='groupName',
+                                           )
+        self.assertEqual(200, response.status_code)
+        obs = json.loads(response.data)
+        self.assertDictEqual({'tree': [7], 'other_stuff': None}, obs)
+
 
 class TaxonomyGroupAPITests(FlaskTests):
 

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -142,7 +142,7 @@ class Taxonomy(ModelBase):
         tree_data = ((i, lineage.split('; '))
                      for i, lineage in self._features['Taxon'].items())
         self.taxonomy_tree = skbio.TreeNode.from_taxonomy(tree_data)
-        for node in self.taxonomy_tree:
+        for node in self.taxonomy_tree.traverse():
             node.length = 1
         self.bp_tree = parse_newick(str(self.taxonomy_tree))
 

--- a/microsetta_public_api/models/_taxonomy.py
+++ b/microsetta_public_api/models/_taxonomy.py
@@ -7,6 +7,7 @@ import biom
 import numpy as np
 import pandas as pd
 import scipy.sparse as ss
+from bp import parse_newick
 
 from microsetta_public_api.exceptions import (DisjointError, UnknownID,
                                               SubsetError)
@@ -136,6 +137,14 @@ class Taxonomy(ModelBase):
         if formatter is None:
             formatter: Formatter = GreengenesFormatter()
         self._formatter = formatter
+
+        # initialize taxonomy tree
+        tree_data = ((i, lineage.split('; '))
+                     for i, lineage in self._features['Taxon'].items())
+        self.taxonomy_tree = skbio.TreeNode.from_taxonomy(tree_data)
+        for node in self.taxonomy_tree:
+            node.length = 1
+        self.bp_tree = parse_newick(str(self.taxonomy_tree))
 
         feature_taxons = self._features
         self._formatted_taxa_names = {i: self._formatter.dict_format(lineage)

--- a/microsetta_public_api/models/tests/test_taxonomy.py
+++ b/microsetta_public_api/models/tests/test_taxonomy.py
@@ -220,6 +220,24 @@ class TaxonomyTests(unittest.TestCase):
         with self.assertRaisesRegex(UnknownID, "foobar"):
             taxonomy.ranks_order(["c", "foobar", ])
 
+    def test_bp_tree(self):
+        taxonomy = Taxonomy(self.table, self.taxonomy_df)
+        bp_tree = taxonomy.bp_tree
+        exp_parens = [1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                      0, 0, 0, 0, 0, 0]
+        obs_parens = list(bp_tree.B)
+        self.assertListEqual(exp_parens, obs_parens)
+        exp_names = [
+            'a', 'b', 'c', 'feature-1', 'd', 'e', 'feature-2', 'f', 'g', 'h',
+            'feature-3',
+        ]
+        obs_names = []
+        for i in range(len(bp_tree.B)):
+            name = bp_tree.name(i)
+            if name is not None:
+                obs_names.append(name)
+        self.assertListEqual(exp_names, obs_names)
+
     def test_get_group(self):
         taxonomy = Taxonomy(self.table, self.taxonomy_df)
         exp = GroupTaxonomy(name='sample-2',

--- a/microsetta_public_api/repo/_taxonomy_repo.py
+++ b/microsetta_public_api/repo/_taxonomy_repo.py
@@ -1,5 +1,6 @@
 from microsetta_public_api.resources import resources
 from microsetta_public_api.models._taxonomy import Taxonomy as TaxonomyModel
+from microsetta_public_api.exceptions import UnknownResource
 
 
 class TaxonomyRepo:
@@ -19,7 +20,8 @@ class TaxonomyRepo:
 
     def _get_resource(self, name, component=None):
         if name not in self.tables:
-            raise ValueError(f'No table with taxonomy available for `{name}`')
+            raise UnknownResource(f'No table with taxonomy available '
+                                  f'for `{name}`')
         else:
             res = self.tables[name]
             if component is not None:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'scikit-bio',
         'altair',
         'jsonschema',
+        'empress>=1.0.1',
     ],
     package_data={'microsetta_public_api':
                   [


### PR DESCRIPTION
This PR servers a python `Empress` object, which can be used to client side to render an empress display.

Fixes #81 Fixes #82 